### PR TITLE
Update go to 1.4

### DIFF
--- a/orchestration/Dockerfile
+++ b/orchestration/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.3.3
+FROM golang:1.4
 
 ADD . /go/src/github.com/haklop/bazooka/orchestration
 RUN go get -d -v ./...

--- a/parser/Dockerfile
+++ b/parser/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.3.3
+FROM golang:1.4
 
 ADD . /go/src/github.com/haklop/bazooka/parser
 RUN go get -d -v ./...

--- a/parserlang/golang/Dockerfile
+++ b/parserlang/golang/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.3.3
+FROM golang:1.4
 
 ADD . /go/src/github.com/haklop/bazooka/parserlang/golang
 RUN go get -d -v ./...

--- a/parserlang/golang/main.go
+++ b/parserlang/golang/main.go
@@ -157,6 +157,7 @@ func resolveGoImage(version string) (string, error) {
 		"1.3.1":  "bazooka/runner-golang:1.3.1",
 		"1.3.2":  "bazooka/runner-golang:1.3.2",
 		"1.3.3":  "bazooka/runner-golang:1.3.3",
+		"1.4":    "bazooka/runner-golang:1.4",
 		"tip":    "bazooka/runner-golang:latest",
 		"latest": "bazooka/runner-golang:latest",
 	}

--- a/parserlang/java/Dockerfile
+++ b/parserlang/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.3.3
+FROM golang:1.4
 
 ADD . /go/src/github.com/haklop/bazooka/parserlang/java
 RUN go get -d -v ./...

--- a/runner/golang/1.4/Dockerfile
+++ b/runner/golang/1.4/Dockerfile
@@ -1,0 +1,1 @@
+FROM golang:1.4

--- a/runner/golang/build_all.sh
+++ b/runner/golang/build_all.sh
@@ -11,4 +11,4 @@ for d in */ ; do
     popd
 done
 
-$s docker tag bazooka/runner-golang:1.3.3 bazooka/runner-golang:latest
+$s docker tag bazooka/runner-golang:1.4 bazooka/runner-golang:latest

--- a/runner/golang/push_all.sh
+++ b/runner/golang/push_all.sh
@@ -11,5 +11,5 @@ for d in */ ; do
     popd
 done
 
-$s docker tag bazooka/runner-golang:1.3.1 $BZK_REGISTRY_HOST/bazooka/runner-golang:latest
+$s docker tag bazooka/runner-golang:1.4 $BZK_REGISTRY_HOST/bazooka/runner-golang:latest
 $s docker push $BZK_REGISTRY_HOST/bazooka/runner-golang:latest

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.3.3
+FROM golang:1.4
 
 ADD . /go/src/github.com/haklop/bazooka/server
 RUN go get -d -v ./...


### PR DESCRIPTION
Current docker tag `1.4` refers to 1.4rc2 but we should have the final release as soon as the tag is updated
