### PR TITLE
In orchestration, after calling parser, the list of generated files (scripts, Dockerfile, meta files) are now collected and varaints get created in the db before passing them to builder and runner

### DIFF
--- a/commons/file.go
+++ b/commons/file.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"strings"
 )
 
@@ -98,5 +99,10 @@ func copyFileContents(src, dst string) (err error) {
 		return
 	}
 	err = out.Sync()
+
+	// This is an ugly hack to fix sporadic problems with boot2docker and virtualbox
+	// where the copied file is sometimes empty
+	exec.Command("sync").Run()
+
 	return
 }

--- a/commons/parallel/parallel.go
+++ b/commons/parallel/parallel.go
@@ -1,0 +1,60 @@
+package parallel
+
+type Task func() error
+type TaskCallback func(interface{}, error)
+
+type Parallel struct {
+	taskChan  chan taskCompletion
+	tasks     []taskWrapper
+	remaining int
+}
+
+type taskWrapper struct {
+	task Task
+	tag  interface{}
+}
+
+type taskCompletion struct {
+	tag interface{}
+	err error
+}
+
+func New() *Parallel {
+	return &Parallel{
+		make(chan taskCompletion),
+		[]taskWrapper{},
+		0,
+	}
+}
+
+func (p *Parallel) Submit(task Task, tag interface{}) {
+	p.tasks = append(p.tasks, taskWrapper{task, tag})
+}
+
+func (p *Parallel) Exec(callback TaskCallback) {
+	p.remaining = len(p.tasks)
+	if p.remaining == 0 {
+		return
+	}
+	for _, w := range p.tasks {
+		wrapper := w
+		go func() {
+			if err := wrapper.task(); err != nil {
+				p.taskChan <- taskCompletion{wrapper.tag, err}
+				return
+			}
+			p.taskChan <- taskCompletion{wrapper.tag, nil}
+
+		}()
+	}
+
+	for {
+		c := <-p.taskChan
+		callback(c.tag, c.err)
+		p.remaining--
+		if p.remaining == 0 {
+			close(p.taskChan)
+			return
+		}
+	}
+}

--- a/commons/parallel/parallel_test.go
+++ b/commons/parallel/parallel_test.go
@@ -1,0 +1,53 @@
+package parallel
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExec(t *testing.T) {
+	type taskCase struct {
+		tag      interface{}
+		err      error
+		duration time.Duration
+	}
+	cases := [][]taskCase{
+		{{"1", nil, 100 * time.Millisecond}, {"2", nil, 0 * time.Millisecond}},
+		{{"1", nil, 100 * time.Millisecond}, {"2", nil, 200 * time.Millisecond}},
+		{{"1", nil, 100 * time.Millisecond}, {"2", fmt.Errorf("lol wut"), 200 * time.Millisecond}},
+		{{"1", fmt.Errorf("oh snap"), 0 * time.Millisecond}, {"2", fmt.Errorf("lol wut"), 0 * time.Millisecond}},
+	}
+
+	for _, cas := range cases {
+		par := New()
+		called := map[interface{}]bool{}
+		expectedErrs := map[interface{}]error{}
+		for _, itc := range cas {
+			tc := itc
+			expectedErrs[tc.tag] = tc.err
+			par.Submit(func() error {
+				time.Sleep(tc.duration)
+				called[tc.tag] = true
+				return tc.err
+			}, tc.tag)
+
+		}
+		par.Exec(func(tag interface{}, err error) {
+			expectedErr, found := expectedErrs[tag]
+			if !found {
+				t.Fatalf("callback called with an unknown tag %#v", tag)
+			}
+			require.Equal(t, expectedErr, err, "The task associated with the tag %#v didn't return the expected error", tag)
+		})
+
+		for _, tc := range cas {
+			c, found := called[tc.tag]
+			require.True(t, found, "The task associated with the tag %#v wasn't called", tc.tag)
+			require.True(t, c, "The task associated with the tag %#v wasn't called", tc.tag)
+		}
+	}
+
+}

--- a/commons/types.go
+++ b/commons/types.go
@@ -13,13 +13,41 @@ type Project struct {
 }
 
 type Variant struct {
-	Status     JobStatus `bson:"status" json:"status"`
-	Started    time.Time `bson:"started" json:"started"`
-	Completed  time.Time `bson:"completed" json:"completed"`
-	BuildImage string    `bson:"image" json:"image"`
-	JobID      string    `bson:"job_id" json:"job_id"`
-	Number     int       `bson:"number" json:"number"`
-	ID         string    `bson:"id" json:"id"`
+	Status     JobStatus     `bson:"status" json:"status"`
+	Started    time.Time     `bson:"started" json:"started"`
+	Completed  time.Time     `bson:"completed" json:"completed"`
+	BuildImage string        `bson:"image" json:"image"`
+	JobID      string        `bson:"job_id" json:"job_id"`
+	Number     int           `bson:"number" json:"number"`
+	ID         string        `bson:"id" json:"id"`
+	Metas      *VariantMetas `bson:"metas" json:"metas"`
+}
+
+type VariantMetas []*VariantMeta
+
+type VariantMeta struct {
+	Kind        MetaKind
+	Name, Value string
+}
+
+type MetaKind string
+
+const (
+	META_ENV  MetaKind = "env"
+	META_LANG          = "lang"
+)
+
+func (ms *VariantMetas) Append(m *VariantMeta) {
+	*ms = append(*ms, m)
+}
+func (ms *VariantMetas) Len() int      { return len(*ms) }
+func (ms *VariantMetas) Swap(i, j int) { (*ms)[i], (*ms)[j] = (*ms)[j], (*ms)[i] }
+func (ms *VariantMetas) Less(i, j int) bool {
+	a, b := (*ms)[i], (*ms)[j]
+	if a.Kind == b.Kind {
+		return a.Name < b.Name
+	}
+	return a.Kind == META_LANG
 }
 
 type StartJob struct {


### PR DESCRIPTION
Fixes #56
