### PR TITLE
Implement a build artifact archiving mechanism

### DIFF
--- a/commons/types.go
+++ b/commons/types.go
@@ -160,7 +160,7 @@ func (c *Commands) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 		return nil
 	default:
-		return fmt.Errorf("Commands (install, script, ...) can be either a tring or a list of strings")
+		return fmt.Errorf("Commands (install, script, ...) can be either a string or a list of strings")
 	}
 }
 

--- a/commons/types.go
+++ b/commons/types.go
@@ -18,6 +18,7 @@ type Variant struct {
 	Started    time.Time     `bson:"started" json:"started"`
 	Completed  time.Time     `bson:"completed" json:"completed"`
 	BuildImage string        `bson:"image" json:"image"`
+	ProjectID  string        `bson:"project_id" json:"job_id"`
 	JobID      string        `bson:"job_id" json:"job_id"`
 	Number     int           `bson:"number" json:"number"`
 	ID         string        `bson:"id" json:"id"`
@@ -118,19 +119,22 @@ type User struct {
 }
 
 type Config struct {
-	Language      string       `yaml:"language"`
-	Setup         Commands     `yaml:"setup,omitempty"`
-	BeforeInstall Commands     `yaml:"before_install,omitempty"`
-	Install       Commands     `yaml:"install,omitempty"`
-	BeforeScript  Commands     `yaml:"before_script,omitempty"`
-	Script        Commands     `yaml:"script,omitempty"`
-	AfterScript   Commands     `yaml:"after_script,omitempty"`
-	AfterSuccess  Commands     `yaml:"after_success,omitempty"`
-	AfterFailure  Commands     `yaml:"after_failure,omitempty"`
-	Services      []string     `yaml:"services,omitempty"`
-	Env           []string     `yaml:"env,omitempty"`
-	FromImage     string       `yaml:"from"`
-	Matrix        ConfigMatrix `yaml:"matrix,omitempty"`
+	Language       string       `yaml:"language"`
+	Setup          Commands     `yaml:"setup,omitempty"`
+	BeforeInstall  Commands     `yaml:"before_install,omitempty"`
+	Install        Commands     `yaml:"install,omitempty"`
+	BeforeScript   Commands     `yaml:"before_script,omitempty"`
+	Script         Commands     `yaml:"script,omitempty"`
+	AfterScript    Commands     `yaml:"after_script,omitempty"`
+	AfterSuccess   Commands     `yaml:"after_success,omitempty"`
+	AfterFailure   Commands     `yaml:"after_failure,omitempty"`
+	Services       []string     `yaml:"services,omitempty"`
+	Env            []string     `yaml:"env,omitempty"`
+	FromImage      string       `yaml:"from"`
+	Matrix         ConfigMatrix `yaml:"matrix,omitempty"`
+	Archive        Globs        `yaml:"archive,omitempty"`
+	ArchiveSuccess Globs        `yaml:"archive_success,omitempty"`
+	ArchiveFailure Globs        `yaml:"archive_failure,omitempty"`
 }
 
 type Commands []string
@@ -157,6 +161,33 @@ func (c *Commands) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return nil
 	default:
 		return fmt.Errorf("Commands (install, script, ...) can be either a tring or a list of strings")
+	}
+}
+
+type Globs []string
+
+func (g *Globs) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var raw interface{}
+	if err := unmarshal(&raw); err != nil {
+		return err
+	}
+
+	switch convGlob := raw.(type) {
+	case string:
+		*g = []string{convGlob}
+		return nil
+	case []interface{}:
+		*g = make([]string, len(convGlob))
+		for i, rawGlob := range convGlob {
+			glob, ok := rawGlob.(string)
+			if !ok {
+				return fmt.Errorf("Globs (archive, archive_success, archive_failure) can only contain strings")
+			}
+			(*g)[i] = glob
+		}
+		return nil
+	default:
+		return fmt.Errorf("Globs (archive, archive_success, archive_failure) can be either a tring or a list of strings")
 	}
 }
 

--- a/orchestration/main.go
+++ b/orchestration/main.go
@@ -8,16 +8,17 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	docker "github.com/bywan/go-dockercommand"
 	lib "github.com/bazooka-ci/bazooka/commons"
 	bzklog "github.com/bazooka-ci/bazooka/commons/logs"
 	"github.com/bazooka-ci/bazooka/commons/mongo"
+	docker "github.com/bywan/go-dockercommand"
 )
 
 const (
-	CheckoutFolderPattern = "%s/source"
-	WorkdirFolderPattern  = "%s/work"
-	MetaFolderPattern     = "%s/meta"
+	CheckoutFolderPattern  = "%s/source"
+	WorkdirFolderPattern   = "%s/work"
+	MetaFolderPattern      = "%s/meta"
+	ArtifactsFolderPattern = "%s/artifacts"
 
 	BazookaInput   = "/bazooka"
 	DockerSock     = "/var/run/docker.sock"
@@ -131,11 +132,12 @@ func main() {
 
 	for i, v := range parsedVariants {
 		variant := &lib.Variant{
-			Started: time.Now(),
-			Status:  lib.JOB_RUNNING,
-			Number:  i,
-			JobID:   env[BazookaEnvJobID],
-			Metas:   v.meta,
+			Started:   time.Now(),
+			Status:    lib.JOB_RUNNING,
+			Number:    i,
+			ProjectID: env[BazookaEnvProjectID],
+			JobID:     env[BazookaEnvJobID],
+			Metas:     v.meta,
 		}
 		err := connector.AddVariant(variant)
 		if err != nil {
@@ -178,10 +180,12 @@ func main() {
 		}
 	}
 
+	artifactsBase := fmt.Sprintf(ArtifactsFolderPattern, env[BazookaEnvHome])
 	r := &Runner{
-		Variants: variantsToBuild,
-		Env:      env,
-		Mongo:    connector,
+		Variants:            variantsToBuild,
+		ArtifactsFolderBase: artifactsBase,
+		Env:                 env,
+		Mongo:               connector,
 	}
 
 	err = r.Run(containerLogger)

--- a/orchestration/runner.go
+++ b/orchestration/runner.go
@@ -83,7 +83,7 @@ func (r *Runner) runContainer(logger Logger, vd *variantData, env map[string]str
 		serviceContainers = append(serviceContainers, serviceContainer)
 	}
 
-	arctifactsFolder := fmt.Sprintf("%s/%s", r.ArtifactsFolderBase, vd.variant.ID)
+	artifactsFolder := fmt.Sprintf("%s/%s", r.ArtifactsFolderBase, vd.variant.ID)
 
 	// TODO link containers
 	container, err := r.client.Run(&docker.RunOptions{
@@ -91,7 +91,7 @@ func (r *Runner) runContainer(logger Logger, vd *variantData, env map[string]str
 		Links: containerLinks,
 		VolumeBinds: []string{
 			fmt.Sprintf("%s:/var/run/docker.sock", DockerSock),
-			fmt.Sprintf("%s:/artifacts", arctifactsFolder),
+			fmt.Sprintf("%s:/artifacts", artifactsFolder),
 		},
 		Detach: true,
 	})

--- a/orchestration/runner.go
+++ b/orchestration/runner.go
@@ -8,17 +8,18 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	docker "github.com/bywan/go-dockercommand"
 	commons "github.com/bazooka-ci/bazooka/commons"
 	"github.com/bazooka-ci/bazooka/commons/mongo"
 	"github.com/bazooka-ci/bazooka/commons/parallel"
+	docker "github.com/bywan/go-dockercommand"
 )
 
 type Runner struct {
-	Variants []*variantData
-	Env      map[string]string
-	Mongo    *mongo.MongoConnector
-	client   *docker.Docker
+	Variants            []*variantData
+	ArtifactsFolderBase string
+	Env                 map[string]string
+	Mongo               *mongo.MongoConnector
+	client              *docker.Docker
 }
 
 func (r *Runner) Run(logger Logger) error {
@@ -82,12 +83,15 @@ func (r *Runner) runContainer(logger Logger, vd *variantData, env map[string]str
 		serviceContainers = append(serviceContainers, serviceContainer)
 	}
 
+	arctifactsFolder := fmt.Sprintf("%s/%s", r.ArtifactsFolderBase, vd.variant.ID)
+
 	// TODO link containers
 	container, err := r.client.Run(&docker.RunOptions{
 		Image: vd.imageTag,
 		Links: containerLinks,
 		VolumeBinds: []string{
 			fmt.Sprintf("%s:/var/run/docker.sock", DockerSock),
+			fmt.Sprintf("%s:/artifacts", arctifactsFolder),
 		},
 		Detach: true,
 	})

--- a/server/main.go
+++ b/server/main.go
@@ -74,6 +74,7 @@ func main() {
 
 	r.HandleFunc("/variant/{id}", mkHandler(ctx.getVariant)).Methods("GET")
 	r.HandleFunc("/variant/{id}/log", mkHandler(ctx.getVariantLog)).Methods("GET")
+	r.HandleFunc("/variant/{id}/artifacts/{path:.*}", ctx.getVariantArtifacts).Methods("GET")
 
 	r.HandleFunc("/image", mkHandler(ctx.getImages)).Methods("GET")
 	r.HandleFunc("/image/{name:.*}", mkHandler(ctx.setImage)).Methods("PUT")


### PR DESCRIPTION
This feature relies on the following configuration keys:

* archive: takes a single or a list of globs. The matching files are archived regardless of the result of the build
* archive_success: takes a single or a list of globs. The matching files are archived in case of a successfull build
* archive_failure: takes a single or a list of globs. The matching files are archived in case of a failed build

The archived files are then exposed over http using the following endpoint:

bzk_server:3000/variant/{id}/artifacts/{path}

Where id is the variant id and path the path to an archived artifact.

Fixes #144