### PR TITLE
Enable secure content in bazooka.yml

### DIFF
--- a/cli/bzk/bzk.go
+++ b/cli/bzk/bzk.go
@@ -54,6 +54,8 @@ func main() {
 		cmd.Command("create", "Create a new bazooka user", createUserCommand)
 	})
 
+	app.Command("encrypt", "Encrypt some data", encryptData)
+
 	app.Command("run", "Run bazooka", run)
 
 	app.Command("login", "Log in to the bazooka server", login)

--- a/cli/bzk/client.go
+++ b/cli/bzk/client.go
@@ -246,6 +246,28 @@ func (c *Client) UpdateKey(projectID, keyPath string) (*lib.SSHKey, error) {
 	return updatedKey, err
 }
 
+func (c *Client) EncryptData(projectID, toEncryptString string) (string, error) {
+	toEncryptData := &lib.StringValue{
+		Value: toEncryptString,
+	}
+
+	requestURL, err := c.getRequestURL(fmt.Sprintf("project/%s/crypto", url.QueryEscape(projectID)))
+	if err != nil {
+		return "", err
+	}
+
+	encryptedData := &lib.StringValue{}
+
+	err = perigee.Put(requestURL, perigee.Options{
+		ReqBody:    &toEncryptData,
+		Results:    &encryptedData,
+		OkCodes:    []int{200},
+		SetHeaders: c.authenticateRequest,
+	})
+
+	return encryptedData.Value, err
+}
+
 func (c *Client) JobLog(jobID string) ([]lib.LogEntry, error) {
 	var log []lib.LogEntry
 

--- a/cli/bzk/crypto.go
+++ b/cli/bzk/crypto.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/jawher/mow.cli"
+)
+
+func encryptData(cmd *cli.Cmd) {
+	pid := cmd.String(cli.StringArg{
+		Name: "PROJECT_ID",
+		Desc: "Project id",
+	})
+	toEncryptData := cmd.String(cli.StringArg{
+		Name: "DATA",
+		Desc: "Data to Encrypt",
+	})
+
+	cmd.Action = func() {
+		client, err := NewClient(checkServerURI(*bzkUri))
+		if err != nil {
+			log.Fatal(err)
+		}
+		res, err := client.EncryptData(*pid, *toEncryptData)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		fmt.Println("Encrypted data: (to add to your .bazooka.yml file)")
+		fmt.Printf("%s\n", res)
+	}
+}

--- a/commons/config.go
+++ b/commons/config.go
@@ -14,10 +14,10 @@ const (
 	travisConfigFile  = ".travis.yml"
 )
 
-func FlattenEnvMap(mapp map[string]string) []string {
-	res := []string{}
+func FlattenEnvMap(mapp map[BzkString]BzkString) []BzkString {
+	res := []BzkString{}
 	for key, value := range mapp {
-		res = append(res, fmt.Sprintf("%s=%s", key, value))
+		res = append(res, BzkString(fmt.Sprintf("%s=%s", key, value)))
 	}
 	return res
 }
@@ -60,11 +60,10 @@ func Flush(object interface{}, outputFile string) error {
 	}
 	return ioutil.WriteFile(outputFile, d, 0644)
 }
-
-func GetEnvMap(envArray []string) map[string][]string {
+func GetEnvMap(envArray []BzkString) map[string][]string {
 	envKeyMap := make(map[string][]string)
 	for _, env := range envArray {
-		envSplit := strings.Split(env, "=")
+		envSplit := strings.Split(string(env), "=")
 		envKeyMap[envSplit[0]] = append(envKeyMap[envSplit[0]], envSplit[1])
 	}
 	return envKeyMap

--- a/commons/crypto.go
+++ b/commons/crypto.go
@@ -1,0 +1,47 @@
+package bazooka
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"io"
+)
+
+// Encrypt encrypts some data with the key
+func Encrypt(key, text []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	b := base64.StdEncoding.EncodeToString(text)
+	ciphertext := make([]byte, aes.BlockSize+len(b))
+	iv := ciphertext[:aes.BlockSize]
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		return nil, err
+	}
+	cfb := cipher.NewCFBEncrypter(block, iv)
+	cfb.XORKeyStream(ciphertext[aes.BlockSize:], []byte(b))
+	return ciphertext, nil
+}
+
+// Decrypt decrypts some data with the key
+func Decrypt(key, text []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	if len(text) < aes.BlockSize {
+		return nil, errors.New("ciphertext too short")
+	}
+	iv := text[:aes.BlockSize]
+	text = text[aes.BlockSize:]
+	cfb := cipher.NewCFBDecrypter(block, iv)
+	cfb.XORKeyStream(text, text)
+	data, err := base64.StdEncoding.DecodeString(string(text))
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}

--- a/commons/crypto.go
+++ b/commons/crypto.go
@@ -6,7 +6,9 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
+	"io/ioutil"
 )
 
 // Encrypt encrypts some data with the key
@@ -44,4 +46,27 @@ func Decrypt(key, text []byte) ([]byte, error) {
 		return nil, err
 	}
 	return data, nil
+}
+
+func ReadCryptoKey(filePath string) ([]byte, error) {
+	exists, err := FileExists(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("Error while trying to check existence of file: %s, reason is: %v\n", filePath, err)
+	}
+
+	if !exists {
+		return nil, fmt.Errorf("Your bazooka config contains secured data but the keyfile can not be found at %s, reason is: %v\n", filePath, err)
+	}
+
+	key, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("Error while reading crypto key file: %s, reason is: %v\n", filePath, err)
+	}
+	return key, nil
+}
+
+func LoadCryptoKeyFromFile(filePath string) error {
+	var err error
+	PrivateKey, err = ReadCryptoKey(filePath)
+	return err
 }

--- a/commons/mongo/crypto.go
+++ b/commons/mongo/crypto.go
@@ -1,0 +1,56 @@
+package mongo
+
+import (
+	"github.com/bazooka-ci/bazooka/commons"
+	"gopkg.in/mgo.v2/bson"
+)
+
+func (c *MongoConnector) GetProjectCryptoKey(projectID string) (*bazooka.CryptoKey, error) {
+	result := &bazooka.CryptoKey{}
+	if err := c.ByField("crypto", "project_id", projectID, result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *MongoConnector) UpdateCryptoKey(id string, key *bazooka.CryptoKey) error {
+	return c.database.C("crypto").Update(bson.M{
+		"project_id": id,
+	}, key)
+}
+
+func (c *MongoConnector) HasCryptoKey(projectID string) (bool, error) {
+	request := bson.M{"project_id": projectID}
+	count, err := c.database.C("crypto").Find(request).Count()
+	return count > 0, err
+}
+
+func (c *MongoConnector) AddCryptoKey(key *bazooka.CryptoKey) error {
+	hasKey, err := c.HasCryptoKey(key.ProjectID)
+	if err != nil {
+		return err
+	}
+	if hasKey {
+		return c.UpdateCryptoKey(key.ProjectID, key)
+	}
+	if key.ID, err = c.randomId(); err != nil {
+		return err
+	}
+
+	return c.database.C("crypto").Insert(key)
+}
+
+func (c *MongoConnector) GetCryptoKeys(projectID string) ([]*bazooka.CryptoKey, error) {
+	proj, err := c.GetProjectById(projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	result := []*bazooka.CryptoKey{}
+
+	err = c.database.C("crypto").Find(bson.M{
+		"project_id": proj.ID,
+	}).All(&result)
+
+	return result, err
+}

--- a/commons/types.go
+++ b/commons/types.go
@@ -3,12 +3,11 @@ package bazooka
 import (
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"time"
 )
 
-const (
-	CRYPTOKEYFILE = "/bazooka-cryptokey"
+var (
+	PrivateKey []byte
 )
 
 type Project struct {
@@ -266,9 +265,8 @@ func extractBzkString(raw interface{}) (BzkString, error) {
 }
 
 func decryptBzkString(str string) ([]byte, error) {
-	key, err := readCryptoKey()
-	if err != nil {
-		return nil, err
+	if PrivateKey == nil {
+		return nil, fmt.Errorf("PrivateKey is not set")
 	}
 
 	toDecryptDataAsHex, err := hex.DecodeString(string(str))
@@ -276,28 +274,11 @@ func decryptBzkString(str string) ([]byte, error) {
 		return nil, fmt.Errorf("Unable to decode string as hexa data, reason is: %v\n", err)
 	}
 
-	decrypted, err := Decrypt(key, toDecryptDataAsHex)
+	decrypted, err := Decrypt(PrivateKey, toDecryptDataAsHex)
 	if err != nil {
 		return nil, fmt.Errorf("Error while trying to decrypt data, reason is: %v\n", err)
 	}
 	return decrypted, nil
-}
-
-func readCryptoKey() ([]byte, error) {
-	exists, err := FileExists(CRYPTOKEYFILE)
-	if err != nil {
-		return nil, fmt.Errorf("Error while trying to check existence of file: %s, reason is: %v\n", CRYPTOKEYFILE, err)
-	}
-
-	if !exists {
-		return nil, fmt.Errorf("Your bazooka config contains secured data but the keyfile can not be found at %s, reason is: %v\n", CRYPTOKEYFILE, err)
-	}
-
-	key, err := ioutil.ReadFile(CRYPTOKEYFILE)
-	if err != nil {
-		return nil, fmt.Errorf("Error while reading crypto key file: %s, reason is: %v\n", CRYPTOKEYFILE, err)
-	}
-	return key, nil
 }
 
 type ConfigMatrix struct {

--- a/orchestration/main.go
+++ b/orchestration/main.go
@@ -20,9 +20,9 @@ const (
 	BazookaEnvSCMReference = "BZK_SCM_REFERENCE"
 	BazookaEnvProjectID    = "BZK_PROJECT_ID"
 	BazookaEnvJobID        = "BZK_JOB_ID"
-	
-	BazookaEnvMongoAddr    = "MONGO_PORT_27017_TCP_ADDR"
-	BazookaEnvMongoPort    = "MONGO_PORT_27017_TCP_PORT"
+
+	BazookaEnvMongoAddr = "MONGO_PORT_27017_TCP_ADDR"
+	BazookaEnvMongoPort = "MONGO_PORT_27017_TCP_PORT"
 )
 
 func init() {
@@ -97,11 +97,12 @@ func main() {
 	p := &Parser{
 		MongoConnector: connector,
 		Options: &ParseOptions{
-			InputFolder:    paths.host.source,
-			OutputFolder:   paths.host.work,
-			DockerSock:     paths.host.dockerSock,
-			MetaFolder:     paths.host.meta,
-			Env:            env,
+			InputFolder:   paths.host.source,
+			OutputFolder:  paths.host.work,
+			DockerSock:    paths.host.dockerSock,
+			MetaFolder:    paths.host.meta,
+			CryptoKeyFile: paths.host.cryptoKey,
+			Env:           env,
 		},
 	}
 	parsedVariants, err := p.Parse(containerLogger)

--- a/orchestration/paths.go
+++ b/orchestration/paths.go
@@ -17,6 +17,7 @@ type stdPaths struct {
 	meta           string
 	artifacts      string
 	key            string
+	cryptoKey      string
 	dockerSock     string
 	dockerEndpoint string
 }
@@ -34,6 +35,7 @@ var paths = bzkPaths{
 		"/bazooka/meta",
 		"/bazooka/artifacts",
 		"/bazooka/key",
+		"/bazooka-cryptokey",
 		"/var/run/docker.sock",
 		"unix:///var/run/docker.sock",
 	},
@@ -44,6 +46,7 @@ var paths = bzkPaths{
 		os.Getenv(BazookaEnvHome) + "/meta",
 		os.Getenv(BazookaEnvHome) + "/artifacts",
 		os.Getenv(BazookaEnvSCMKeyfile),
+		os.Getenv(BazookaEnvHome) + "/crypto-key",
 		os.Getenv(BazookaEnvDockerSock),
 		"unix://" + os.Getenv(BazookaEnvDockerSock),
 	},

--- a/parser/generator.go
+++ b/parser/generator.go
@@ -199,7 +199,7 @@ func (g *Generator) GenerateDockerfile() error {
 	}
 
 	for _, env := range g.Config.Env {
-		envSplit := strings.Split(env, "=")
+		envSplit := strings.Split(string(env), "=")
 		dockerBuffer.WriteString(fmt.Sprintf("ENV  %s %s\n", envSplit[0], envSplit[1]))
 	}
 

--- a/parser/language_parser.go
+++ b/parser/language_parser.go
@@ -33,13 +33,14 @@ func (p *LanguageParser) Parse() ([]*variantData, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	container, err := client.Run(&docker.RunOptions{
 		Image: p.Image,
 		VolumeBinds: []string{
 			fmt.Sprintf("%s:/bazooka", paths.host.source),
 			fmt.Sprintf("%s:/bazooka-output", paths.host.output),
 			fmt.Sprintf("%s:/meta", paths.host.meta),
+			fmt.Sprintf("%s:/bazooka-cryptokey", paths.host.cryptoKey),
 		},
 		Detach: true,
 	})

--- a/parser/main.go
+++ b/parser/main.go
@@ -185,10 +185,10 @@ func feedMatrix(extra map[string]interface{}, mx *matrix.Matrix) error {
 		switch k {
 		case "env":
 			if vs, ok := v.([]interface{}); ok {
-				envVars := []string{}
+				envVars := []lib.BzkString{}
 				for _, envVar := range vs {
 					if strEnvVar, ok := envVar.(string); ok {
-						envVars = append(envVars, strEnvVar)
+						envVars = append(envVars, lib.BzkString(strEnvVar))
 					} else {
 						return fmt.Errorf("Invalid config: env should contain a sequence of strings: found a non string value %v:%T", envVar, envVar)
 
@@ -227,10 +227,10 @@ func parseCounter(filePath string) string {
 
 // explodeProps starts from a list of key=valye strings and stores them into a map
 // it also handles repeated values, so ["A=1", "A=2", B="3"] gets transformed into {A: [1, 2], B: [3]}
-func explodeProps(props []string, keyPrefix string) map[string][]string {
+func explodeProps(props []lib.BzkString, keyPrefix string) map[string][]string {
 	envKeyMap := make(map[string][]string)
 	for _, env := range props {
-		envSplit := strings.Split(env, "=")
+		envSplit := strings.Split(string(env), "=")
 		envKeyMap[keyPrefix+envSplit[0]] = append(envKeyMap[keyPrefix+envSplit[0]], envSplit[1])
 	}
 	return envKeyMap
@@ -247,11 +247,11 @@ func prefixMapKeys(m map[string][]string, prefix string) map[string][]string {
 
 // extractPrefixedKeysMap returns a new map containing only the values whose keys have the specified prefix, removing the latter in the process
 // Given {xA: 1, B: 2, xC: 3}, it returns {A: 1, C: 3} if given a prefix x
-func extractPrefixedKeysMap(m map[string]string, prefix string) map[string]string {
-	res := make(map[string]string)
+func extractPrefixedKeysMap(m map[string]string, prefix string) map[lib.BzkString]lib.BzkString {
+	res := make(map[lib.BzkString]lib.BzkString)
 	for k, v := range m {
 		if strings.HasPrefix(k, prefix) {
-			res[k[len(prefix):]] = v
+			res[lib.BzkString(k[len(prefix):])] = lib.BzkString(v)
 		}
 	}
 	return res

--- a/parser/main.go
+++ b/parser/main.go
@@ -19,6 +19,7 @@ const (
 
 func init() {
 	log.SetFormatter(&bzklog.BzkFormatter{})
+	lib.LoadCryptoKeyFromFile("/bazooka-cryptokey")
 }
 
 func main() {

--- a/parser/paths.go
+++ b/parser/paths.go
@@ -16,6 +16,7 @@ type stdPaths struct {
 	output         string
 	dockerSock     string
 	dockerEndpoint string
+	cryptoKey      string
 }
 
 type bzkPaths struct {
@@ -30,6 +31,7 @@ var paths = bzkPaths{
 		"/bazooka-output",
 		"/docker.sock",
 		"unix:///docker.sock",
+		"/bazooka-cryptokey",
 	},
 	stdPaths{
 		os.Getenv(BazookaEnvHome) + "/source",
@@ -37,5 +39,6 @@ var paths = bzkPaths{
 		os.Getenv(BazookaEnvHome) + "/work",
 		"",
 		"",
+		os.Getenv(BazookaEnvHome) + "/crypto-key",
 	},
 }

--- a/server/crypto.go
+++ b/server/crypto.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"encoding/hex"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/bazooka-ci/bazooka/commons"
+)
+
+func (c *context) encryptData(params map[string]string, body bodyFunc) (*response, error) {
+	var v bazooka.StringValue
+
+	body(&v)
+
+	if len(v.Value) == 0 {
+		return badRequest("value is mandatory")
+	}
+
+	_, err := c.Connector.GetProjectById(params["id"])
+	if err != nil {
+		if err.Error() != "not found" {
+			return nil, err
+		}
+		return notFound("project not found")
+	}
+
+	keys, err := c.Connector.GetCryptoKeys(params["id"])
+	if err != nil {
+		return nil, err
+	}
+
+	if len(keys) == 0 {
+		return notFound("Crypto Key not found")
+	}
+
+	keyContent := keys[0].Content
+
+	encrypted, err := bazooka.Encrypt(keyContent, []byte(v.Value))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	encryptedData := &bazooka.StringValue{
+		Value: hex.EncodeToString(encrypted),
+	}
+
+	return ok(&encryptedData)
+}

--- a/server/job.go
+++ b/server/job.go
@@ -136,14 +136,13 @@ func (c *context) startJob(params map[string]string, startJob lib.StartJob) (*re
 	}
 
 	projectCryptoKey, err := c.Connector.GetProjectCryptoKey(project.ID)
-	fmt.Printf("Key: %s\n", projectCryptoKey)
+
 	if err != nil {
 		_, keyNotFound := err.(*mongo.NotFoundError)
 		if !keyNotFound {
 			return nil, err
 		}
 	} else {
-		fmt.Printf("found\n")
 		err = os.MkdirAll(buildFolderLocal, 0644)
 		if err != nil {
 			return nil, err

--- a/server/main.go
+++ b/server/main.go
@@ -71,6 +71,8 @@ func main() {
 	r.HandleFunc("/project/{id}/key", mkHandler(ctx.updateKey)).Methods("PUT")
 	r.HandleFunc("/project/{id}/key", mkHandler(ctx.listKeys)).Methods("GET")
 
+	r.HandleFunc("/project/{id}/crypto", mkHandler(ctx.encryptData)).Methods("PUT")
+
 	r.HandleFunc("/job", mkHandler(ctx.getAllJobs)).Methods("GET")
 	r.HandleFunc("/job/{id}", mkHandler(ctx.getJob)).Methods("GET")
 	r.HandleFunc("/job/{id}/log", mkHandler(ctx.getJobLog)).Methods("GET")

--- a/server/project.go
+++ b/server/project.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
+	"time"
 
 	"github.com/gorilla/mux"
 
@@ -58,7 +60,27 @@ func (p *context) createProject(params map[string]string, body bodyFunc) (*respo
 		return nil, err
 	}
 
+	cryptoKey := &lib.CryptoKey{
+		Content:   []byte(randSeq(32)),
+		ProjectID: project.ID,
+	}
+
+	if err = p.Connector.AddCryptoKey(cryptoKey); err != nil {
+		return nil, err
+	}
+
 	return created(&project, "/project/"+project.ID)
+}
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+
+func randSeq(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		rand.Seed(time.Now().UTC().UnixNano())
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
 }
 
 func (p *context) getProject(params map[string]string, body bodyFunc) (*response, error) {


### PR DESCRIPTION
## The goal

Do something like that:

```yaml
language: golang
go:
  - 1.3.1
after_script:
  - echo $TEST_SECURE
  - echo $TOTO
env:
  - secure: 5d5a074ca963ffedb3e80660f98ae43262e7c58adf40fc31b35a439d7ebdecf2e138b012
  - TOTO=1
```

Only env vars can be encrypted

## How does it work ?

* Each time a new project is created, bazooka generates a key for this project and store it in mongo. Each project has its own key.

* As a user, when you want to encrypt some data, you use `bzk encrypt`

```
Usage: bzk encrypt PROJECT_ID DATA 

Encrypt some data

Arguments:
  PROJECT_ID=""   Project id
  DATA=""         Data to Encrypt
```

* With the encrypted data returned by this command, you add it where you want in your bazooka.yml, like in the previous example.

* When bazooka starts a job, it will look for every `secure: ...` item during yaml unmarshalling and try to decrypt the data. The job then continues with the decrypted bazooka config

Closes #69 
