### PR TITLE
Fix a concurrency bug with the parallel image building

### DIFF
--- a/orchestration/main.go
+++ b/orchestration/main.go
@@ -136,9 +136,9 @@ func main() {
 
 	b := &Builder{
 		Options: &BuildOptions{
-			SourceFolder: paths.container.source,
-			ProjectID:    env[BazookaEnvProjectID],
-			Variants:     parsedVariants,
+			BaseFolder: paths.container.base,
+			ProjectID:  env[BazookaEnvProjectID],
+			Variants:   parsedVariants,
 		},
 	}
 


### PR DESCRIPTION
Before, and after parser has generated the variants scripts and Dockerfiles, orchestration used to build the variants concurrently.

Every variant build consisted of copying the variant scripts and Dockerfile to the source directory and launching a docker build of the image.

This obviously is incorrect, as there is only one source directory and multiple variants

The fix makes use of docker's recent ability to use a custom Dockerfile:
We no longer copy the variant files to the source directory.
Instead, the image build is performed using the job root directory as the build context, and individually adding the variant's script files
to the image (using COPY commands in the variant's Dockerfile).

Fixes #155