### PR TITLE
Add a per-project server-side configuration map

### DIFF
--- a/cli/bzk/bzk.go
+++ b/cli/bzk/bzk.go
@@ -19,6 +19,12 @@ func main() {
 	app.Command("project", "Actions on projects", func(cmd *cli.Cmd) {
 		cmd.Command("list", "List bazooka projects", listProjectsCommand)
 		cmd.Command("create", "Create a new bazooka project", createProjectCommand)
+		cmd.Command("config", "View or modify a bazooka project configuration", func(cfgCmd *cli.Cmd) {
+			cfgCmd.Command("list", "List full project configuration", listProjectConfigCommand)
+			cfgCmd.Command("get", "Get a specific project configuration key", getProjectConfigKeyCommand)
+			cfgCmd.Command("set", "Set a specific project configuration key", setProjectConfigKeyCommand)
+			cfgCmd.Command("unset", "Delete a specific project configuration key", unsetProjectConfigKeyCommand)
+		})
 	})
 
 	app.Command("job", "Actions on jobs", func(cmd *cli.Cmd) {

--- a/cli/bzk/client.go
+++ b/cli/bzk/client.go
@@ -37,6 +37,47 @@ func (c *Client) ListProjects() ([]lib.Project, error) {
 	return p, err
 }
 
+func (c *Client) GetProjectConfig(id string) (map[string]string, error) {
+	var res map[string]string
+
+	requestURL, err := c.getRequestURL(fmt.Sprintf("project/%s/config", id))
+	if err != nil {
+		return nil, err
+	}
+
+	err = perigee.Get(requestURL, perigee.Options{
+		Results:    &res,
+		OkCodes:    []int{200},
+		SetHeaders: c.authenticateRequest,
+	})
+	return res, err
+}
+
+func (c *Client) SetProjectConfigKey(id, key, value string) error {
+
+	requestURL, err := c.getRequestURL(fmt.Sprintf("project/%s/config/%s", id, key))
+	if err != nil {
+		return err
+	}
+	return perigee.Put(requestURL, perigee.Options{
+		ReqBody:    value,
+		OkCodes:    []int{204},
+		SetHeaders: c.authenticateRequest,
+	})
+}
+
+func (c *Client) UnsetProjectConfigKey(id, key string) error {
+
+	requestURL, err := c.getRequestURL(fmt.Sprintf("project/%s/config/%s", id, key))
+	if err != nil {
+		return err
+	}
+	return perigee.Delete(requestURL, perigee.Options{
+		OkCodes:    []int{204},
+		SetHeaders: c.authenticateRequest,
+	})
+}
+
 func (c *Client) ListJobs(projectID string) ([]lib.Job, error) {
 	var j []lib.Job
 

--- a/cli/bzk/project.go
+++ b/cli/bzk/project.go
@@ -69,3 +69,122 @@ func listProjectsCommand(cmd *cli.Cmd) {
 		w.Flush()
 	}
 }
+
+func listProjectConfigCommand(cmd *cli.Cmd) {
+	cmd.Spec = "PROJECT_ID"
+
+	pid := cmd.String(cli.StringArg{
+		Name: "PROJECT_ID",
+		Desc: "the project id",
+	})
+
+	cmd.Action = func() {
+		client, err := NewClient(checkServerURI(*bzkUri))
+		if err != nil {
+			log.Fatal(err)
+		}
+		res, err := client.GetProjectConfig(*pid)
+		if err != nil {
+			log.Fatal(err)
+		}
+		w := tabwriter.NewWriter(os.Stdout, 15, 1, 3, ' ', 0)
+		fmt.Fprint(w, "KEY\tVALUE\n")
+
+		for k, v := range res {
+			fmt.Fprintf(w, "%s\t%s\n", k, v)
+		}
+		w.Flush()
+	}
+}
+
+func getProjectConfigKeyCommand(cmd *cli.Cmd) {
+	cmd.Spec = "PROJECT_ID KEY"
+
+	pid := cmd.String(cli.StringArg{
+		Name: "PROJECT_ID",
+		Desc: "the project id",
+	})
+
+	key := cmd.String(cli.StringArg{
+		Name: "KEY",
+		Desc: "the configuration key",
+	})
+
+	cmd.Action = func() {
+		client, err := NewClient(checkServerURI(*bzkUri))
+		if err != nil {
+			log.Fatal(err)
+		}
+		res, err := client.GetProjectConfig(*pid)
+		if err != nil {
+			log.Fatal(err)
+		}
+		w := tabwriter.NewWriter(os.Stdout, 15, 1, 3, ' ', 0)
+		fmt.Fprint(w, "KEY\tVALUE\n")
+
+		v, found := res[*key]
+		if !found {
+			v = "<not set>"
+		}
+
+		fmt.Fprintf(w, "%s\t%s\n", *key, v)
+		w.Flush()
+	}
+}
+
+func setProjectConfigKeyCommand(cmd *cli.Cmd) {
+	cmd.Spec = "PROJECT_ID KEY VALUE"
+
+	pid := cmd.String(cli.StringArg{
+		Name: "PROJECT_ID",
+		Desc: "the project id",
+	})
+
+	key := cmd.String(cli.StringArg{
+		Name: "KEY",
+		Desc: "the configuration key",
+	})
+
+	value := cmd.String(cli.StringArg{
+		Name: "VALUE",
+		Desc: "the configuration value",
+	})
+
+	cmd.Action = func() {
+		client, err := NewClient(checkServerURI(*bzkUri))
+		if err != nil {
+			log.Fatal(err)
+		}
+		if err := client.SetProjectConfigKey(*pid, *key, *value); err != nil {
+			log.Fatal(err)
+		}
+		w := tabwriter.NewWriter(os.Stdout, 15, 1, 3, ' ', 0)
+		fmt.Fprint(w, "KEY\tVALUE\n")
+		fmt.Fprintf(w, "%s\t%s\n", *key, *value)
+		w.Flush()
+	}
+}
+
+func unsetProjectConfigKeyCommand(cmd *cli.Cmd) {
+	cmd.Spec = "PROJECT_ID KEY"
+
+	pid := cmd.String(cli.StringArg{
+		Name: "PROJECT_ID",
+		Desc: "the project id",
+	})
+
+	key := cmd.String(cli.StringArg{
+		Name: "KEY",
+		Desc: "the configuration key",
+	})
+
+	cmd.Action = func() {
+		client, err := NewClient(checkServerURI(*bzkUri))
+		if err != nil {
+			log.Fatal(err)
+		}
+		if err := client.UnsetProjectConfigKey(*pid, *key); err != nil {
+			log.Fatal(err)
+		}
+	}
+}

--- a/commons/mongo/project.go
+++ b/commons/mongo/project.go
@@ -56,6 +56,54 @@ func (c *MongoConnector) AddProject(project *lib.Project) error {
 	return c.database.C("projects").Insert(project)
 }
 
+func (c *MongoConnector) SetProjectConfig(id string, config map[string]string) error {
+	proj, err := c.GetProjectById(id)
+	if err != nil {
+		return err
+	}
+	selector := bson.M{
+		"id": proj.ID,
+	}
+	request := bson.M{
+		"$set": bson.M{
+			"config": config,
+		},
+	}
+	return c.database.C("projects").Update(selector, request)
+}
+
+func (c *MongoConnector) SetProjectConfigKey(id, key, value string) error {
+	proj, err := c.GetProjectById(id)
+	if err != nil {
+		return err
+	}
+	selector := bson.M{
+		"id": proj.ID,
+	}
+	request := bson.M{
+		"$set": bson.M{
+			fmt.Sprintf("config.%s", key): value,
+		},
+	}
+	return c.database.C("projects").Update(selector, request)
+}
+
+func (c *MongoConnector) UnsetProjectConfigKey(id, key string) error {
+	proj, err := c.GetProjectById(id)
+	if err != nil {
+		return err
+	}
+	selector := bson.M{
+		"id": proj.ID,
+	}
+	request := bson.M{
+		"$unset": bson.M{
+			fmt.Sprintf("config.%s", key): "",
+		},
+	}
+	return c.database.C("projects").Update(selector, request)
+}
+
 func (c *MongoConnector) AddJob(job *lib.Job) error {
 	var err error
 	if job.ID, err = c.randomId(); err != nil {

--- a/commons/types.go
+++ b/commons/types.go
@@ -6,11 +6,12 @@ import (
 )
 
 type Project struct {
-	ScmType    string `bson:"scm_type" json:"scm_type"`
-	ScmURI     string `bson:"scm_uri" json:"scm_uri"`
-	Name       string `bson:"name" json:"name"`
-	ID         string `bson:"id" json:"id"`
-	JobCounter int    `bson:"job_counter" json:"job_counter"`
+	ScmType    string            `bson:"scm_type" json:"scm_type"`
+	ScmURI     string            `bson:"scm_uri" json:"scm_uri"`
+	Name       string            `bson:"name" json:"name"`
+	ID         string            `bson:"id" json:"id"`
+	JobCounter int               `bson:"job_counter" json:"job_counter"`
+	Config     map[string]string `bson:"config" json:"config"`
 }
 
 type Variant struct {

--- a/server/main.go
+++ b/server/main.go
@@ -63,6 +63,10 @@ func main() {
 	r.HandleFunc("/project/{id}/github", mkHandler(ctx.startGithubJob)).Methods("POST")
 	r.HandleFunc("/project/{id}/job", mkHandler(ctx.getJobs)).Methods("GET")
 
+	r.HandleFunc("/project/{id}/config", mkHandler(ctx.getProjectConfig)).Methods("GET")
+	r.HandleFunc("/project/{id}/config/{key}", ctx.setProjectConfigKey).Methods("PUT")
+	r.HandleFunc("/project/{id}/config/{key}", mkHandler(ctx.unsetProjectConfigKey)).Methods("DELETE")
+
 	r.HandleFunc("/project/{id}/key", mkHandler(ctx.addKey)).Methods("POST")
 	r.HandleFunc("/project/{id}/key", mkHandler(ctx.updateKey)).Methods("PUT")
 	r.HandleFunc("/project/{id}/key", mkHandler(ctx.listKeys)).Methods("GET")

--- a/server/server.go
+++ b/server/server.go
@@ -62,6 +62,12 @@ func ok(payload interface{}) (*response, error) {
 	}, nil
 }
 
+func noContent() (*response, error) {
+	return &response{
+		Code: 204,
+	}, nil
+}
+
 func created(payload interface{}, location string) (*response, error) {
 	return &response{
 		201,


### PR DESCRIPTION
This will be useful for the following cases:

* #63 project specific build system: the config can be used to store the build docker image to run
* #145 reuse scm checkout: to configure whether a project has to perform a fresh checkout or update an existing one
* Possibly #129 injecting project specific values into a job