### PR TITLE
Fix dot handling in project config keys and extra quotes around the settings values

### DIFF
--- a/cli/bzk/client.go
+++ b/cli/bzk/client.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 
 	lib "github.com/bazooka-ci/bazooka/commons"
 	"github.com/racker/perigee"
@@ -54,15 +55,15 @@ func (c *Client) GetProjectConfig(id string) (map[string]string, error) {
 }
 
 func (c *Client) SetProjectConfigKey(id, key, value string) error {
-
 	requestURL, err := c.getRequestURL(fmt.Sprintf("project/%s/config/%s", id, key))
 	if err != nil {
 		return err
 	}
 	return perigee.Put(requestURL, perigee.Options{
-		ReqBody:    value,
-		OkCodes:    []int{204},
-		SetHeaders: c.authenticateRequest,
+		ContentType: "text/plain",
+		ReqBody:     strings.NewReader(value),
+		OkCodes:     []int{204},
+		SetHeaders:  c.authenticateRequest,
 	})
 }
 


### PR DESCRIPTION
Setting a project config key containing a dot would create a sub document in mongo.
Mongo doesn't support escaping dots in the key names.
The proposed fix is to replace dots with something (// in this case) before submitting them to mongo, and to unescape them back the other way around

Also, the cli submited config values were wrapped into extra quotes.