### PR TITLE
Support scm checkout updating instead of performing a fresh checkout on every build

### DIFF
--- a/docs/home/project_configuration.md
+++ b/docs/home/project_configuration.md
@@ -1,0 +1,23 @@
+# Project Configuration
+
+Bazooka's philosophy tries to have every build-related configuration stored and versionned in a text file besides the other project files.
+
+However, some cases just don't fit this model, especially for configuration values required before even checking-out the project source code.
+
+To this effect, bazooka comes with a facility to store a key value structured configuration in the server.
+
+The CLI can be used to list, view, set and delete these configuration values using the `bzk project config` command.
+Please refer to the CLI help messages for more details on using this command.
+
+## Standard configuration keys
+### bzk.scm.reuse
+
+If this key is set to `true`, using the CLI for example:
+
+`bzk project config set $PROJECT-NAME bzk.scm.reuse true`
+
+Then instead of performing a fresh checkout of the project source code on every build, bazooka will instead checkout the project only once, and then perform an in-place update to the latest version.
+
+This can be useful for large projects or when behind a slow network.
+
+By default, the key is not set.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ pages:
 - ['home/secured_variables.md', 'Bazooka', 'Secured Variables']
 - ['home/permutations.md', 'Bazooka', 'Permutations']
 - ['home/services.md', 'Bazooka', 'Services']
+- ['home/project_configuration.md', 'Bazooka', 'Project Configuration']
 - ['home/cli.md', 'Bazooka', 'Bazooka CLI']
 - ['home/travis.md', 'Bazooka', 'Travis Compatibility']
 - ['languages/java.md', 'Language guides', 'Java']

--- a/orchestration/parser.go
+++ b/orchestration/parser.go
@@ -53,6 +53,7 @@ func (p *Parser) Parse(logger Logger) ([]*variantData, error) {
 
 	env := map[string]string{
 		"BZK_HOME": paths.host.base,
+		"BZK_SRC": paths.host.source,
 	}
 	for k, v := range p.Options.Env {
 		env[k] = v

--- a/orchestration/paths.go
+++ b/orchestration/paths.go
@@ -6,6 +6,7 @@ import (
 
 const (
 	BazookaEnvHome       = "BZK_HOME"
+	BazookaEnvSrc        = "BZK_SRC"
 	BazookaEnvSCMKeyfile = "BZK_SCM_KEYFILE"
 	BazookaEnvDockerSock = "BZK_DOCKERSOCK"
 )
@@ -41,7 +42,7 @@ var paths = bzkPaths{
 	},
 	stdPaths{
 		os.Getenv(BazookaEnvHome),
-		os.Getenv(BazookaEnvHome) + "/source",
+		os.Getenv(BazookaEnvSrc),
 		os.Getenv(BazookaEnvHome) + "/work",
 		os.Getenv(BazookaEnvHome) + "/meta",
 		os.Getenv(BazookaEnvHome) + "/artifacts",

--- a/parser/paths.go
+++ b/parser/paths.go
@@ -6,6 +6,7 @@ import (
 
 const (
 	BazookaEnvHome       = "BZK_HOME"
+	BazookaEnvSrc        = "BZK_SRC"
 	BazookaEnvSCMKeyfile = "BZK_SCM_KEYFILE"
 	BazookaEnvDockerSock = "BZK_DOCKERSOCK"
 )
@@ -34,7 +35,7 @@ var paths = bzkPaths{
 		"/bazooka-cryptokey",
 	},
 	stdPaths{
-		os.Getenv(BazookaEnvHome) + "/source",
+		os.Getenv(BazookaEnvSrc),
 		os.Getenv(BazookaEnvHome) + "/meta",
 		os.Getenv(BazookaEnvHome) + "/work",
 		"",


### PR DESCRIPTION
This is useful for projects with a big footprint, where checkouting could take a couple minutes.

The proposed solution works as follow:

- A project must first be configured to do an update instead of a fresh checkout using the project configuration feature, by setting the "bzk.scm.reuse" key to "true". The cli can be used to this effect: `bzk project config set <project-name> bzk.scm.reuse true`
- When the server receives a start job request, it reads this configuration value. If set to true, a project-level (`$BZK_HOME/build/<project-id>/source`) folder is created if it does not already exist, and gets mounted into orchestration at `/bazooka/source`, on top of the job directory which still gets mounted at `/bazooka`
- The orchestration container is also passed an env var `BZK_REUSE_SCM_CHECKOUT` set to `1`
- In orchestration, and upon startup, if the `BZK_REUSE_SCM_CHECKOUT` env var is set, the scm checkout container is started with the env var `UPDATE` set to a non empty value. Depending on the project scm (git or hg for the time being), the container performs an in place update (git pull or hg update for example). See bazooka-ci/bazooka-scm-git#1 and bazooka-ci/bazooka-scm-hg#1 for details on the specifics
- If this fails, orchestration re-runs the scm container again without the `UPDATE` env var, in case this is the first build or the osurce directory was deleted, which would perform a regular fresh checkout

Fixes #145.