### PR TITLE
Move environment variable constants name into orchestration/paths

### DIFF
--- a/orchestration/main.go
+++ b/orchestration/main.go
@@ -15,12 +15,6 @@ import (
 )
 
 const (
-	BazookaEnvSCM          = "BZK_SCM"
-	BazookaEnvSCMUrl       = "BZK_SCM_URL"
-	BazookaEnvSCMReference = "BZK_SCM_REFERENCE"
-	BazookaEnvProjectID    = "BZK_PROJECT_ID"
-	BazookaEnvJobID        = "BZK_JOB_ID"
-
 	BazookaEnvMongoAddr = "MONGO_PORT_27017_TCP_ADDR"
 	BazookaEnvMongoPort = "MONGO_PORT_27017_TCP_PORT"
 )

--- a/orchestration/paths.go
+++ b/orchestration/paths.go
@@ -5,9 +5,14 @@ import (
 )
 
 const (
-	BazookaEnvHome       = "BZK_HOME"
-	BazookaEnvSCMKeyfile = "BZK_SCM_KEYFILE"
-	BazookaEnvDockerSock = "BZK_DOCKERSOCK"
+	BazookaEnvHome         = "BZK_HOME"
+	BazookaEnvSCMKeyfile   = "BZK_SCM_KEYFILE"
+	BazookaEnvDockerSock   = "BZK_DOCKERSOCK"
+	BazookaEnvSCM          = "BZK_SCM"
+	BazookaEnvSCMUrl       = "BZK_SCM_URL"
+	BazookaEnvSCMReference = "BZK_SCM_REFERENCE"
+	BazookaEnvProjectID    = "BZK_PROJECT_ID"
+	BazookaEnvJobID        = "BZK_JOB_ID"
 )
 
 type stdPaths struct {


### PR DESCRIPTION
Some input environment variables were missing in orchestration/paths.go