### PR TITLE
Allow job parameters

### DIFF
--- a/cli/bzk/client.go
+++ b/cli/bzk/client.go
@@ -152,9 +152,10 @@ func (c *Client) CreateProject(name, scm, scmUri string) (*lib.Project, error) {
 	return createdProject, err
 }
 
-func (c *Client) StartJob(projectID, scmReference string) (*lib.Job, error) {
+func (c *Client) StartJob(projectID, scmReference string, envParameters []string) (*lib.Job, error) {
 	startJob := lib.StartJob{
 		ScmReference: scmReference,
+		Parameters:   envParameters,
 	}
 	createdJob := &lib.Job{}
 

--- a/cli/bzk/job.go
+++ b/cli/bzk/job.go
@@ -45,7 +45,7 @@ func fmtAuthor(author lib.Person) string {
 }
 
 func startJobCommand(cmd *cli.Cmd) {
-	cmd.Spec = "PROJECT_ID [SCM_REF]"
+	cmd.Spec = "PROJECT_ID [SCM_REF] [--env...]"
 
 	pid := cmd.String(cli.StringArg{
 		Name: "PROJECT_ID",
@@ -56,6 +56,10 @@ func startJobCommand(cmd *cli.Cmd) {
 		Desc:  "the scm ref to build",
 		Value: "master",
 	})
+	envParameters := cmd.Strings(cli.StringsOpt{
+		Name: "e env",
+		Desc: "define an environment variable for the job",
+	})
 
 	cmd.Action = func() {
 
@@ -63,7 +67,7 @@ func startJobCommand(cmd *cli.Cmd) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		res, err := client.StartJob(*pid, *scmRef)
+		res, err := client.StartJob(*pid, *scmRef, *envParameters)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/commons/config.go
+++ b/commons/config.go
@@ -65,7 +65,11 @@ func GetEnvMap(envArray []BzkString) map[string][]string {
 	envKeyMap := make(map[string][]string)
 	for _, env := range envArray {
 		envSplit := strings.SplitN(string(env), "=", 2)
-		envKeyMap[envSplit[0]] = append(envKeyMap[envSplit[0]], envSplit[1])
+		value := ""
+		if len(envSplit) == 2 {
+			value = envSplit[1]
+		}
+		envKeyMap[envSplit[0]] = append(envKeyMap[envSplit[0]], value)
 	}
 	return envKeyMap
 }

--- a/commons/config.go
+++ b/commons/config.go
@@ -60,6 +60,7 @@ func Flush(object interface{}, outputFile string) error {
 	}
 	return ioutil.WriteFile(outputFile, d, 0644)
 }
+
 func GetEnvMap(envArray []BzkString) map[string][]string {
 	envKeyMap := make(map[string][]string)
 	for _, env := range envArray {

--- a/commons/config.go
+++ b/commons/config.go
@@ -64,7 +64,7 @@ func Flush(object interface{}, outputFile string) error {
 func GetEnvMap(envArray []BzkString) map[string][]string {
 	envKeyMap := make(map[string][]string)
 	for _, env := range envArray {
-		envSplit := strings.Split(string(env), "=")
+		envSplit := strings.SplitN(string(env), "=", 2)
 		envKeyMap[envSplit[0]] = append(envKeyMap[envSplit[0]], envSplit[1])
 	}
 	return envKeyMap

--- a/commons/types.go
+++ b/commons/types.go
@@ -60,7 +60,8 @@ func (ms *VariantMetas) Less(i, j int) bool {
 }
 
 type StartJob struct {
-	ScmReference string `json:"reference"`
+	ScmReference string   `json:"reference"`
+	Parameters   []string `json:"parameters"`
 }
 
 type JobStatus string
@@ -81,6 +82,7 @@ type Job struct {
 	Completed       time.Time   `bson:"completed" json:"completed"`
 	Status          JobStatus   `bson:"status" json:"status"`
 	SCMMetadata     SCMMetadata `bson:"scm_metadata" json:"scm_metadata"`
+	Parameters      []string    `bson:"parameters" json:"parameters"`
 }
 
 type LogEntry struct {

--- a/orchestration/main.go
+++ b/orchestration/main.go
@@ -15,11 +15,12 @@ import (
 )
 
 const (
-	BazookaEnvSCM          = "BZK_SCM"
-	BazookaEnvSCMUrl       = "BZK_SCM_URL"
-	BazookaEnvSCMReference = "BZK_SCM_REFERENCE"
-	BazookaEnvProjectID    = "BZK_PROJECT_ID"
-	BazookaEnvJobID        = "BZK_JOB_ID"
+	BazookaEnvSCM           = "BZK_SCM"
+	BazookaEnvSCMUrl        = "BZK_SCM_URL"
+	BazookaEnvSCMReference  = "BZK_SCM_REFERENCE"
+	BazookaEnvProjectID     = "BZK_PROJECT_ID"
+	BazookaEnvJobID         = "BZK_JOB_ID"
+	BazookaEnvJobParameters = "BZK_JOB_PARAMETERS"
 
 	BazookaEnvMongoAddr = "MONGO_PORT_27017_TCP_ADDR"
 	BazookaEnvMongoPort = "MONGO_PORT_27017_TCP_PORT"
@@ -40,11 +41,12 @@ func main() {
 	defer connector.Close()
 
 	env := map[string]string{
-		BazookaEnvSCM:          os.Getenv(BazookaEnvSCM),
-		BazookaEnvSCMUrl:       os.Getenv(BazookaEnvSCMUrl),
-		BazookaEnvSCMReference: os.Getenv(BazookaEnvSCMReference),
-		BazookaEnvProjectID:    os.Getenv(BazookaEnvProjectID),
-		BazookaEnvJobID:        os.Getenv(BazookaEnvJobID),
+		BazookaEnvSCM:           os.Getenv(BazookaEnvSCM),
+		BazookaEnvSCMUrl:        os.Getenv(BazookaEnvSCMUrl),
+		BazookaEnvSCMReference:  os.Getenv(BazookaEnvSCMReference),
+		BazookaEnvProjectID:     os.Getenv(BazookaEnvProjectID),
+		BazookaEnvJobID:         os.Getenv(BazookaEnvJobID),
+		BazookaEnvJobParameters: os.Getenv(BazookaEnvJobParameters),
 	}
 
 	var containerLogger Logger = func(image string, variantID string, container *docker.Container) {

--- a/orchestration/parser.go
+++ b/orchestration/parser.go
@@ -171,7 +171,7 @@ func parseMeta(file string, vf *variantData) error {
 						if strings.HasPrefix(strEnvVar, "BZK_") {
 							continue
 						}
-						nv := strings.Split(strEnvVar, "=")
+						nv := strings.SplitN(strEnvVar, "=", 2)
 						vf.meta.Append(&lib.VariantMeta{Kind: lib.META_ENV, Name: nv[0], Value: nv[1]})
 					} else {
 						return fmt.Errorf("Invalid config: env should contain a sequence of strings: found a non string value %v:%T", envVar, envVar)

--- a/orchestration/runner.go
+++ b/orchestration/runner.go
@@ -37,7 +37,7 @@ func (r *Runner) Run(logger Logger) error {
 		}
 		variant := ivariant
 		par.Submit(func() error {
-			return r.runContainer(logger, variant, r.Env)
+			return r.runContainer(logger, variant)
 		}, variant)
 	}
 
@@ -58,7 +58,7 @@ func (r *Runner) Run(logger Logger) error {
 	return nil
 }
 
-func (r *Runner) runContainer(logger Logger, vd *variantData, env map[string]string) error {
+func (r *Runner) runContainer(logger Logger, vd *variantData) error {
 	success := true
 	servicesFile := fmt.Sprintf("%s/%d/services", paths.container.work, vd.counter)
 
@@ -70,7 +70,7 @@ func (r *Runner) runContainer(logger Logger, vd *variantData, env map[string]str
 	serviceContainers := []*docker.Container{}
 	containerLinks := []string{}
 	for _, service := range servicesList {
-		name := fmt.Sprintf("service-%s-%s-%d", env[BazookaEnvProjectID], env[BazookaEnvJobID], vd.variant.Number)
+		name := fmt.Sprintf("service-%s-%s-%d", r.Env[BazookaEnvProjectID], r.Env[BazookaEnvJobID], vd.variant.Number)
 		containerLinks = append(containerLinks, fmt.Sprintf("%s:%s", name, service))
 		serviceContainer, err := r.client.Run(&docker.RunOptions{
 			Name:   name,

--- a/parser/generator.go
+++ b/parser/generator.go
@@ -199,7 +199,7 @@ func (g *Generator) GenerateDockerfile() error {
 	}
 
 	for _, env := range g.Config.Env {
-		envSplit := strings.Split(string(env), "=")
+		envSplit := strings.SplitN(string(env), "=", 2)
 		dockerBuffer.WriteString(fmt.Sprintf("ENV  %s %s\n", envSplit[0], envSplit[1]))
 	}
 

--- a/parser/main.go
+++ b/parser/main.go
@@ -258,7 +258,7 @@ func parseCounter(filePath string) string {
 func explodeProps(props []lib.BzkString, keyPrefix string) map[string][]string {
 	envKeyMap := make(map[string][]string)
 	for _, env := range props {
-		envSplit := strings.Split(string(env), "=")
+		envSplit := strings.SplitN(string(env), "=", 2)
 		value := ""
 		if len(envSplit) == 2 {
 			value = envSplit[1]


### PR DESCRIPTION
We can now use `bzk job start` for injecting parameters to the job:

```
Usage: bzk job start PROJECT_ID [SCM_REF] [--env...]

Start a new bazooka job on a project

Arguments:
  PROJECT_ID=""      the project id
  SCM_REF="master"   the scm ref to build

Options:
  -e, --env=[]string(nil)   define an environment variable for the job
```
E.g.:
```bzk job start my-project my-branch -e A=3 -e B=42```

Permutation can be created by settings multiple times the same variable:
```bzk job start my-project my-branch -e A=3 -e A=5````

Settings defined on the project's configuration map are also injected. 

The `.bazooka.yml` can define mandatory parameters by adding an entry in the env section without value:
```
env:
  - A
  - B=5
```
`A` has to be defined on the project's configuration map or at the start of the job.

Parameters are exposed as environment variable.

Closes #129