### PR TITLE
Fix a bug where if the variants of a job had different list of metas

### DIFF
--- a/web/src/job/job.html
+++ b/web/src/job/job.html
@@ -8,7 +8,7 @@
 				<th>Variant</th>
 				<th>Duration</th>
 				<th>Finished</th>
-				<th ng-repeat="label in metaLabels" class="meta">{{label}}</th>
+				<th ng-repeat="m in metaList" class="meta">{{m.label}}</th>
 			</tr>
 		</thead>
 
@@ -18,7 +18,7 @@
 				<td><a ng-href="#/p/{{project | bzkId}}/{{job | bzkId}}/{{variant | bzkId}}">{{job.number}}.{{variant.number}}</a></td>
 				<td>{{variant | bzkDuration}}</td>
 				<td>{{variant | bzkFinished}}</td>
-				<td ng-repeat="vmeta in variant.metas" class="meta" ng-style="{'color': metaColor(vmeta)}">{{vmeta.value}}</td>
+				<td ng-repeat="m in metaList" class="meta" ng-style="{'color': metaColor(variant.metaMap[m.name])}">{{variant.metaMap[m.name].value}}</td>
 			</tr>
 		</tbody>
 	</table>

--- a/web/src/job/jobController.js
+++ b/web/src/job/jobController.js
@@ -94,36 +94,49 @@ angular.module('bzk.job').controller('JobController', function($scope, BzkApi, $
             '#000000'
         ];
 
-        var metaLabels = [],
+        var metaList = [],
             colors = {};
         if (variants.length > 0) {
-            var vref = variants[0];
-            _.each(vref.metas, function(m) {
-                metaLabels.push(m.kind == 'env' ? '$' + m.name : m.name);
-            });
-
-            _.each(vref.metas, function(m, i) {
-                var mcolors = {};
-                colors[m.name] = mcolors;
-                var colIdx = 0;
-                _.each(variants, function(v) {
-                    var val = v.metas[i].value;
-                    if (!mcolors[val]) {
-                        mcolors[val] = colorsDb[colIdx];
-                        if (colIdx < colorsDb.length - 1) {
-                            colIdx++;
-                        }
+            var visitedMeta = {};
+            _.each(variants, function(v) {
+                v.metaMap = _.indexBy(v.metas, 'name');
+                _.each(v.metas, function(m) {
+                    if (!visitedMeta[m.name]) {
+                        metaList.push(m);
+                        m.label = m.kind == 'env' ? '$' + m.name : m.name;
+                        visitedMeta[m.name] = true;
                     }
                 });
             });
 
+            _.each(metaList, function(m) {
+                var mcolors = {};
+                colors[m.name] = mcolors;
+                var colIdx = 0;
+                _.each(variants, function(v) {
+                    var vm = _.findWhere(v.metas, {
+                        name: m.name
+                    });
+                    if (vm) {
+                        var val = vm.value;
+                        if (!mcolors[val]) {
+                            mcolors[val] = colorsDb[colIdx];
+                            if (colIdx < colorsDb.length - 1) {
+                                colIdx++;
+                            }
+                        }
+                    }
+                });
+            });
         }
 
-        $scope.metaLabels = metaLabels;
+        $scope.metaList = metaList;
         $scope.metaColors = colors;
     }
 
     $scope.metaColor = function(vmeta) {
-        return $scope.metaColors[vmeta.name][vmeta.value];
+        if (vmeta) {
+            return $scope.metaColors[vmeta.name][vmeta.value];
+        }
     };
 });


### PR DESCRIPTION
(one with `go:1.4` and another with `image:my-image` for example), the job would group both in one single column

Fixes #151