### PR TITLE
Move `make images` in script phase

### DIFF
--- a/.bazooka.yml
+++ b/.bazooka.yml
@@ -6,9 +6,10 @@ install:
 script:
   - go test -v ./...
   - make errcheck
+  - make images
 after_success:
   - make bintray
-  - make images push
+  - make push
 env:
   - BZK_BUILD_DIR=/go/src/github.com/bazooka-ci/bazooka
   # DOCKER_USERNAME=****


### PR DESCRIPTION
Making bazooka images does not depend on external services, and should be a part of the script phase, since building bazooka images is like compiling our application