### PR TITLE
Wait for mongodb to start accepting TCP connections (for 5s at most) before trying to connect to it

### DIFF
--- a/commons/net.go
+++ b/commons/net.go
@@ -1,0 +1,24 @@
+package bazooka
+
+import (
+	"fmt"
+	"net"
+	"time"
+)
+
+func WaitForTcpConnection(host, port string, retryEvery, timeout time.Duration) error {
+	url := fmt.Sprintf("%s:%s", host, port)
+	giveUp := time.After(timeout)
+	for {
+		select {
+		case <-time.After(retryEvery):
+			conn, err := net.DialTimeout("tcp", url, 100*time.Millisecond)
+			if err == nil {
+				conn.Close()
+				return nil
+			}
+		case <-giveUp:
+			return fmt.Errorf("Coudln't establish a connection to %s:%s after %v", host, port, timeout)
+		}
+	}
+}

--- a/server/main.go
+++ b/server/main.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
+
+	lib "github.com/bazooka-ci/bazooka/commons"
 
 	log "github.com/Sirupsen/logrus"
 	bzklog "github.com/bazooka-ci/bazooka/commons/logs"
@@ -38,6 +41,10 @@ func main() {
 	}
 
 	// Configure Mongo
+	if err := lib.WaitForTcpConnection(env[BazookaEnvMongoAddr], env[BazookaEnvMongoPort], 100*time.Millisecond, 5*time.Second); err != nil {
+		log.Fatalf("Cannot connect to the database: %v", err)
+	}
+
 	connector := mongo.NewConnector()
 	defer connector.Close()
 


### PR DESCRIPTION
This is done server-side and not in the CLI (as suggested by the linked issue), this way this safeguard works regardless of how the server is started.

Fixes #171