### PR TITLE
Enable custom mongo settings

### DIFF
--- a/cli/bzk/config.go
+++ b/cli/bzk/config.go
@@ -27,6 +27,8 @@ type Config struct {
 	DockerSock string `yaml:"docker_sock"`
 	SCMKey     string `yaml:"scm_key"`
 	Registry   string `yaml:"registry"`
+
+	MongoURI string `yaml:"mongo_uri"`
 }
 
 func saveConfig(authConfig *Config) error {

--- a/cli/bzk/service.go
+++ b/cli/bzk/service.go
@@ -33,6 +33,11 @@ func startService(cmd *cli.Cmd) {
 		Desc:   "Location of the private SSH Key Bazooka will use for SCM Fetch",
 		EnvVar: "BZK_SCM_KEYFILE",
 	})
+	mongoURI := cmd.String(cli.StringOpt{
+		Name:   "mongo-uri",
+		Desc:   "URI of a MongoDB server",
+		EnvVar: "BZK_MONGO_URI",
+	})
 	registry := cmd.String(cli.StringOpt{
 		Name:   "registry",
 		EnvVar: "BZK_REGISTRY",
@@ -48,7 +53,7 @@ func startService(cmd *cli.Cmd) {
 	})
 
 	cmd.Action = func() {
-		config, err := getConfigWithParams(*bzkHome, *dockerSock, *registry, *scmKey)
+		config, err := getConfigWithParams(*bzkHome, *dockerSock, *registry, *scmKey, *mongoURI)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -266,7 +271,7 @@ func getContainerStatus(name string) bool {
 
 }
 
-func getConfigWithParams(bzkHome, dockerSock, registry, scmKey string) (*Config, error) {
+func getConfigWithParams(bzkHome, dockerSock, registry, scmKey, mongoURI string) (*Config, error) {
 	config, err := loadConfig()
 	if err != nil {
 		return nil, fmt.Errorf("Unable to load Bazooka config, reason is: %v\n", err)
@@ -294,6 +299,10 @@ func getConfigWithParams(bzkHome, dockerSock, registry, scmKey string) (*Config,
 		config.SCMKey = scmKey
 	}
 
+	if len(mongoURI) != 0 {
+		config.MongoURI = mongoURI
+	}
+
 	if len(registry) != 0 {
 		config.Registry = registry
 	}
@@ -307,7 +316,7 @@ func getConfigWithParams(bzkHome, dockerSock, registry, scmKey string) (*Config,
 }
 
 func getConfig() (*Config, error) {
-	return getConfigWithParams("", "", "", "")
+	return getConfigWithParams("", "", "", "", "")
 }
 
 func restartContainer(client *docker.Docker, options *docker.RunOptions) error {

--- a/cli/bzk/service.go
+++ b/cli/bzk/service.go
@@ -12,6 +12,12 @@ import (
 	dockerclient "github.com/fsouza/go-dockerclient"
 )
 
+const (
+	bzkContainerMongo  = "bzk_mongodb"
+	bzkContainerServer = "bzk_server"
+	bzkContainerWeb    = "bzk_web"
+)
+
 var allContainers []dockerclient.APIContainers
 
 func startService(cmd *cli.Cmd) {
@@ -121,7 +127,7 @@ func doRestartService() {
 }
 
 func getTagFromCurrentImages(client *docker.Docker) (string, error) {
-	container, err := getContainer(allContainers, "bzk_server")
+	container, err := getContainer(allContainers, bzkContainerServer)
 	if err != nil {
 		// Container not found, using latest by default
 		return "latest", nil
@@ -181,17 +187,17 @@ func stopService(cmd *cli.Cmd) {
 			log.Fatal(err)
 		}
 
-		err = stopContainer(client, "bzk_mongodb")
+		err = stopContainer(client, bzkContainerMongo)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		err = stopContainer(client, "bzk_server")
+		err = stopContainer(client, bzkContainerServer)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		err = stopContainer(client, "bzk_web")
+		err = stopContainer(client, bzkContainerWeb)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -212,9 +218,9 @@ func statusService(cmd *cli.Cmd) {
 			log.Fatal(err)
 		}
 
-		mongoUp := getContainerStatus("bzk_mongodb")
-		serverUp := getContainerStatus("bzk_server")
-		webUp := getContainerStatus("bzk_web")
+		mongoUp := getContainerStatus(bzkContainerMongo)
+		serverUp := getContainerStatus(bzkContainerServer)
+		webUp := getContainerStatus(bzkContainerWeb)
 
 		if mongoUp && serverUp && webUp {
 			fmt.Printf("Bazooka service is Up\n")
@@ -383,7 +389,7 @@ func contains(slice []string, item string) bool {
 
 func getMongoRunOptions() *docker.RunOptions {
 	return &docker.RunOptions{
-		Name: "bzk_mongodb",
+		Name: bzkContainerMongo,
 		// Using the official mongo image from dockerhub, this may need a change later
 		Image:  "mongo:3.0.2",
 		Detach: true,
@@ -392,7 +398,7 @@ func getMongoRunOptions() *docker.RunOptions {
 
 func getServerRunOptions(registry, bzkHome, dockerSock, scmKey, tag string) *docker.RunOptions {
 	return &docker.RunOptions{
-		Name:   "bzk_server",
+		Name:   bzkContainerServer,
 		Image:  getImageLocation(registry, "bazooka/server", tag),
 		Detach: true,
 		VolumeBinds: []string{
@@ -409,7 +415,7 @@ func getServerRunOptions(registry, bzkHome, dockerSock, scmKey, tag string) *doc
 
 func getWebRunOptions(registry, tag string) *docker.RunOptions {
 	return &docker.RunOptions{
-		Name:   "bzk_web",
+		Name:   bzkContainerWeb,
 		Image:  getImageLocation(registry, "bazooka/web", tag),
 		Detach: true,
 		Links:  []string{"bzk_server:server"},

--- a/commons/mongo/connector.go
+++ b/commons/mongo/connector.go
@@ -12,6 +12,7 @@ import (
 const (
 	bazookaEnvMongoAddr = "MONGO_PORT_27017_TCP_ADDR"
 	bazookaEnvMongoPort = "MONGO_PORT_27017_TCP_PORT"
+	bazookaEnvMongoURI  = "BZK_MONGO_URI"
 	bazookaMongoBase    = "bazooka"
 )
 
@@ -42,7 +43,7 @@ func (m *ManyFoundError) Error() string {
 }
 
 func NewConnector() *MongoConnector {
-	session, err := mgo.Dial(os.Getenv(bazookaEnvMongoAddr) + ":" + os.Getenv(bazookaEnvMongoPort))
+	session, err := mgo.Dial(getMongoUri())
 	if err != nil {
 		panic(err)
 	}
@@ -122,4 +123,12 @@ func (m *MongoConnector) ByIdOrName(collection, id string, result interface{}) e
 		return err
 	}
 
+}
+
+func getMongoUri() string {
+	mongoURI := os.Getenv(bazookaEnvMongoURI)
+	if mongoURI != "" {
+		return mongoURI
+	}
+	return os.Getenv(bazookaEnvMongoAddr) + ":" + os.Getenv(bazookaEnvMongoPort)
 }

--- a/docs/cli/service.md
+++ b/docs/cli/service.md
@@ -27,6 +27,7 @@ Start bazooka
 Options:
   --home=""          Bazooka's work directory ($BZK_HOME)
   --scm-key=""       Location of the private SSH Key Bazooka will use for SCM Fetch ($BZK_SCM_KEYFILE)
+  --mongo-uri=""     URI of a MongoDB server ($BZK_MONGO_URI)
   --registry=""      ($BZK_REGISTRY)
   --docker-sock=""   Location of the Docker unix socket, usually /var/run/docker.sock ($BZK_DOCKERSOCK)
   --tag=""           The bazooka version to run


### PR DESCRIPTION
Add a --mongo-uri option on bzk service start to enable use of an external MongoDB server.

```
bzk service start --mongo-uri=mongodb://user:password@my-mongo-instance:1234/my-database-name