### PR TITLE
Fix JS error in a job page

### DIFF
--- a/web/src/variant/variant.js
+++ b/web/src/variant/variant.js
@@ -48,8 +48,6 @@ angular.module('bzk.variant').controller('VariantController', function($scope, B
         }
     }
     refresh();
-
-    $scope.$on('$routeUpdate', refresh);
 });
 
 angular.module('bzk.variant').controller('VariantLogsController', function($scope, BzkApi, $routeParams, $timeout) {


### PR DESCRIPTION
jobController.js occasionally throws an error if the variants lists is loaded before the job itself