### PR TITLE
Protect the encrypted values in a job's metadata

### DIFF
--- a/commons/config.go
+++ b/commons/config.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"strings"
 
 	yaml "gopkg.in/yaml.v2"
 )
@@ -14,10 +13,10 @@ const (
 	travisConfigFile  = ".travis.yml"
 )
 
-func FlattenEnvMap(mapp map[BzkString]BzkString) []BzkString {
+func FlattenEnvMap(mapp map[string][]BzkString) []BzkString {
 	res := []BzkString{}
-	for key, value := range mapp {
-		res = append(res, BzkString(fmt.Sprintf("%s=%s", key, value)))
+	for _, value := range mapp {
+		res = append(res, value...)
 	}
 	return res
 }
@@ -61,15 +60,10 @@ func Flush(object interface{}, outputFile string) error {
 	return ioutil.WriteFile(outputFile, d, 0644)
 }
 
-func GetEnvMap(envArray []BzkString) map[string][]string {
-	envKeyMap := make(map[string][]string)
+func GetEnvMap(envArray []BzkString) map[string][]BzkString {
+	envKeyMap := make(map[string][]BzkString)
 	for _, env := range envArray {
-		envSplit := strings.SplitN(string(env), "=", 2)
-		value := ""
-		if len(envSplit) == 2 {
-			value = envSplit[1]
-		}
-		envKeyMap[envSplit[0]] = append(envKeyMap[envSplit[0]], value)
+		envKeyMap[env.Name] = append(envKeyMap[env.Name], env)
 	}
 	return envKeyMap
 }


### PR DESCRIPTION
This solution extends BzkString to make a string instead of a just an alias for string with 3 fields:

* name: the environement variable name
* value: the environement variable value
* secured: a boolean flag indicating if the variable is secured or not

When unmarshalling a `.bazooka.yml`, the custom BzkString unmarshaller fills these fields accordingly.

`BzkString` now also implements the `yaml.Marshaller` interface. This way, when a config struct is persisted to disk, the secured values get encrypted again

When language parser generates the variants bazooka files, and the parser parses them, the secured values are correctly marked so.

Finally, when the parser generates the metadata file for a variant, the secured variables are encrypted before storing them.

Fixes #193

Be sure to test with a patched golang parser suing this patch: bazooka-ci/bazooka-lang-go#5