### PR TITLE
Improve validation: use tagName 'validate' to add constraints on a field

### DIFF
--- a/commons/types.go
+++ b/commons/types.go
@@ -14,9 +14,9 @@ var (
 )
 
 type Project struct {
-	ScmType    string            `bson:"scm_type" json:"scm_type"`
-	ScmURI     string            `bson:"scm_uri" json:"scm_uri"`
-	Name       string            `bson:"name" json:"name"`
+	ScmType    string            `bson:"scm_type" json:"scm_type" validate:"required"`
+	ScmURI     string            `bson:"scm_uri" json:"scm_uri" validate:"required"`
+	Name       string            `bson:"name" json:"name" validate:"required"`
 	ID         string            `bson:"id" json:"id"`
 	HookKey    string            `bson:"hook_key" json:"hook_key"`
 	JobCounter int               `bson:"job_counter" json:"job_counter"`
@@ -405,5 +405,5 @@ type CryptoKey struct {
 }
 
 type StringValue struct {
-	Value string `bson:"value" json:"value"`
+	Value string `bson:"value" json:"value" validate:"required"`
 }

--- a/server/crypto.go
+++ b/server/crypto.go
@@ -12,10 +12,6 @@ func (c *context) encryptData(r *request) (*response, error) {
 
 	r.parseBody(&v)
 
-	if len(v.Value) == 0 {
-		return badRequest("value is mandatory")
-	}
-
 	_, err := c.Connector.GetProjectById(r.vars["id"])
 	if err != nil {
 		if err.Error() != "not found" {

--- a/server/project.go
+++ b/server/project.go
@@ -14,15 +14,6 @@ func (p *context) createProject(r *request) (*response, error) {
 
 	r.parseBody(&project)
 
-	switch {
-	case len(project.ScmURI) == 0:
-		return badRequest("scm_uri is mandatory")
-	case len(project.ScmType) == 0:
-		return badRequest("scm_type is mandatory")
-	case len(project.Name) == 0:
-		return badRequest("name is mandatory")
-	}
-
 	exists, err := p.Connector.HasProject(project.Name)
 	switch {
 	case err != nil:


### PR DESCRIPTION
Use gopkg.in/bluesuncorp/validator.v5 to validate submitted JSON.

Simply add the validate tag on a field to set constraints:
```
type Project struct {
	ScmType    string            `bson:"scm_type" json:"scm_type" validate:"required"`
	ScmURI     string            `bson:"scm_uri" json:"scm_uri" validate:"required"`
	Name       string            `bson:"name" json:"name" validate:"required"`
	ID         string            `bson:"id" json:"id"`
	JobCounter int               `bson:"job_counter" json:"job_counter"`
	Config     map[string]string `bson:"config" json:"config"`
}
```

We can use all the validators defined here https://godoc.org/gopkg.in/bluesuncorp/validator.v5#hdr-Baked_In_Validators_and_Tags

It's possible to create custom validator if necessary.

I use the package reflect to generate friendly error messages.