### PR TITLE
Move push actions in script phase

### DIFF
--- a/.bazooka.yml
+++ b/.bazooka.yml
@@ -8,7 +8,6 @@ script:
   - make errcheck
   - make cli-gox
   - make images
-after_success:
   - make push-bintray
   - make push
 env:


### PR DESCRIPTION
Since these actions are conditionnal, and only done when some
env vars are present, they should be part of the script, and fail
the job if the push fails