### PR TITLE
Add built-in php support

### DIFF
--- a/parser/main.go
+++ b/parser/main.go
@@ -342,6 +342,7 @@ func resolveLanguageParser(language string) (string, error) {
 		"python":  "bazooka/parser-python",
 		"node_js": "bazooka/parser-nodejs",
 		"nodejs":  "bazooka/parser-nodejs",
+		"php":     "bazooka/parser-php",
 	}
 	if val, ok := parserMap[language]; ok {
 		return val, nil


### PR DESCRIPTION
Add built-in php support.

PHP runners and parser are on [bazooka-lang-php project](https://github.com/bazooka-ci/bazooka-lang-php).

The PR for the docs: https://github.com/bazooka-ci/docs/pull/7