### PR TITLE
CLI tries to display a default value when user input is required.

### DIFF
--- a/cli/bzk/client.go
+++ b/cli/bzk/client.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"runtime"
 
 	"github.com/bazooka-ci/bazooka/client"
 )
@@ -23,7 +24,11 @@ func NewClient() (*client.Client, error) {
 func checkServerURI(endpoint string, cliConfig *Config) string {
 	if len(endpoint) == 0 {
 		if len(cliConfig.ServerURI) == 0 {
-			endpoint = interactiveInput("Bazooka Server URI")
+			var defaultURI = "http://localhost:3000"
+			if runtime.GOOS == "darwin" {
+				defaultURI = "http://192.168.59.103:3000"
+			}
+			endpoint = interactiveInput("Bazooka Server URI", defaultURI)
 			cliConfig.ServerURI = endpoint
 
 			if err := saveConfig(cliConfig); err != nil {

--- a/cli/bzk/input.go
+++ b/cli/bzk/input.go
@@ -7,8 +7,8 @@ import (
 	"os"
 )
 
-func interactiveInput(name string) string {
-	fmt.Printf("%s: ", name)
+func interactiveInput(name, defaultValue string) string {
+	fmt.Printf("%s [%s]:", name, defaultValue)
 	bio := bufio.NewReader(os.Stdin)
 	input, isPrefix, err := bio.ReadLine()
 
@@ -18,6 +18,10 @@ func interactiveInput(name string) string {
 
 	if isPrefix {
 		log.Fatalf("%s is too long", name)
+	}
+
+	if len(input) == 0 {
+		return defaultValue
 	}
 
 	return string(input[:])

--- a/cli/bzk/login.go
+++ b/cli/bzk/login.go
@@ -22,7 +22,7 @@ func login(cmd *cli.Cmd) {
 
 	cmd.Action = func() {
 		if len(*email) == 0 {
-			*email = interactiveInput("Email")
+			*email = interactiveInput("Email", "")
 		}
 
 		if len(*password) == 0 {

--- a/cli/bzk/service.go
+++ b/cli/bzk/service.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"os/user"
 	"strings"
 
 	"github.com/jawher/mow.cli"
@@ -274,16 +275,23 @@ func getConfigWithParams(bzkHome, dockerSock, registry, scmKey, mongoURI string)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to load Bazooka config, reason is: %v\n", err)
 	}
+	currentUser, errCurrentUser := user.Current()
+
 	if len(bzkHome) == 0 {
 		if len(config.Home) == 0 {
-			config.Home = interactiveInput("Bazooka Home Folder")
+			defaultHome := ""
+			if errCurrentUser == nil {
+				defaultHome = currentUser.HomeDir + "/bazooka"
+			}
+
+			config.Home = interactiveInput("Bazooka Home Folder", defaultHome)
 		}
 	} else {
 		config.Home = bzkHome
 	}
 	if len(dockerSock) == 0 {
 		if len(config.DockerSock) == 0 {
-			config.DockerSock = interactiveInput("Docker Socket path")
+			config.DockerSock = interactiveInput("Docker Socket path", "/var/run/docker.sock")
 		}
 	} else {
 		config.DockerSock = dockerSock
@@ -291,7 +299,12 @@ func getConfigWithParams(bzkHome, dockerSock, registry, scmKey, mongoURI string)
 
 	if len(scmKey) == 0 {
 		if len(config.SCMKey) == 0 {
-			config.SCMKey = interactiveInput("Bazooka Default SCM private key")
+			defaultSCMKey := ""
+			if errCurrentUser == nil {
+				defaultSCMKey = currentUser.HomeDir + "/.ssh/id_rsa"
+			}
+
+			config.SCMKey = interactiveInput("Bazooka Default SCM private key", defaultSCMKey)
 		}
 	} else {
 		config.SCMKey = scmKey


### PR DESCRIPTION
CLI tries to display a default value when user input is required.

e.g. when the server uri is not defined:
```
▶ bzk project list
Bazooka Server URI [http://192.168.59.103:3000]:
```
or
```
▶ bzk service start
Bazooka Home Folder [/Users/eric/bazooka]:
Docker Socket path [/var/run/docker.sock]:
Bazooka Default SCM private key [/Users/eric/.ssh/id_rsa]:/Users/eric/.ssh/id_custom
```