### PR TITLE
Inject global job parameters

### DIFF
--- a/cli/bzk/bzk.go
+++ b/cli/bzk/bzk.go
@@ -29,7 +29,7 @@ func main() {
 		cmd.Command("env", "View or modify a bazooka project environment variable", func(cfgCmd *cli.Cmd) {
 			cfgCmd.Command("list", "List project environment variables", listProjectEnvCommand)
 			cfgCmd.Command("get", "Get a specific project environment variable", getProjectEnvKeyCommand)
-			cfgCmd.Command("set", "Set a specific projectenvironment variable", setProjectEnvKeyCommand)
+			cfgCmd.Command("set", "Set a specific project environment variable", setProjectEnvKeyCommand)
 			cfgCmd.Command("unset", "Delete a specific project configuration key", unsetProjectEnvKeyCommand)
 		})
 	})

--- a/cli/bzk/bzk.go
+++ b/cli/bzk/bzk.go
@@ -26,6 +26,12 @@ func main() {
 			cfgCmd.Command("set", "Set a specific project configuration key", setProjectConfigKeyCommand)
 			cfgCmd.Command("unset", "Delete a specific project configuration key", unsetProjectConfigKeyCommand)
 		})
+		cmd.Command("env", "View or modify a bazooka project environment variable", func(cfgCmd *cli.Cmd) {
+			cfgCmd.Command("list", "List project environment variables", listProjectEnvCommand)
+			cfgCmd.Command("get", "Get a specific project environment variable", getProjectEnvKeyCommand)
+			cfgCmd.Command("set", "Set a specific projectenvironment variable", setProjectEnvKeyCommand)
+			cfgCmd.Command("unset", "Delete a specific project configuration key", unsetProjectEnvKeyCommand)
+		})
 	})
 
 	app.Command("job", "Actions on jobs", func(cmd *cli.Cmd) {

--- a/cli/bzk/project.go
+++ b/cli/bzk/project.go
@@ -218,3 +218,122 @@ func unsetProjectConfigKeyCommand(cmd *cli.Cmd) {
 		}
 	}
 }
+
+func listProjectEnvCommand(cmd *cli.Cmd) {
+	cmd.Spec = "PROJECT_ID"
+
+	pid := cmd.String(cli.StringArg{
+		Name: "PROJECT_ID",
+		Desc: "the project id",
+	})
+
+	cmd.Action = func() {
+		client, err := NewClient()
+		if err != nil {
+			log.Fatal(err)
+		}
+		res, err := client.Project.Env.Get(*pid)
+		if err != nil {
+			log.Fatal(err)
+		}
+		w := tabwriter.NewWriter(os.Stdout, 15, 1, 3, ' ', 0)
+		fmt.Fprint(w, "KEY\tVALUE\n")
+
+		for k, v := range res {
+			fmt.Fprintf(w, "%s\t%s\n", k, v)
+		}
+		w.Flush()
+	}
+}
+
+func getProjectEnvKeyCommand(cmd *cli.Cmd) {
+	cmd.Spec = "PROJECT_ID KEY"
+
+	pid := cmd.String(cli.StringArg{
+		Name: "PROJECT_ID",
+		Desc: "the project id",
+	})
+
+	key := cmd.String(cli.StringArg{
+		Name: "KEY",
+		Desc: "the configuration key",
+	})
+
+	cmd.Action = func() {
+		client, err := NewClient()
+		if err != nil {
+			log.Fatal(err)
+		}
+		res, err := client.Project.Env.Get(*pid)
+		if err != nil {
+			log.Fatal(err)
+		}
+		w := tabwriter.NewWriter(os.Stdout, 15, 1, 3, ' ', 0)
+		fmt.Fprint(w, "KEY\tVALUE\n")
+
+		v, found := res[*key]
+		if !found {
+			v = "<not set>"
+		}
+
+		fmt.Fprintf(w, "%s\t%s\n", *key, v)
+		w.Flush()
+	}
+}
+
+func setProjectEnvKeyCommand(cmd *cli.Cmd) {
+	cmd.Spec = "PROJECT_ID KEY VALUE"
+
+	pid := cmd.String(cli.StringArg{
+		Name: "PROJECT_ID",
+		Desc: "the project id",
+	})
+
+	key := cmd.String(cli.StringArg{
+		Name: "KEY",
+		Desc: "the configuration key",
+	})
+
+	value := cmd.String(cli.StringArg{
+		Name: "VALUE",
+		Desc: "the configuration value",
+	})
+
+	cmd.Action = func() {
+		client, err := NewClient()
+		if err != nil {
+			log.Fatal(err)
+		}
+		if err := client.Project.Env.SetEnv(*pid, *key, *value); err != nil {
+			log.Fatal(err)
+		}
+		w := tabwriter.NewWriter(os.Stdout, 15, 1, 3, ' ', 0)
+		fmt.Fprint(w, "KEY\tVALUE\n")
+		fmt.Fprintf(w, "%s\t%s\n", *key, *value)
+		w.Flush()
+	}
+}
+
+func unsetProjectEnvKeyCommand(cmd *cli.Cmd) {
+	cmd.Spec = "PROJECT_ID KEY"
+
+	pid := cmd.String(cli.StringArg{
+		Name: "PROJECT_ID",
+		Desc: "the project id",
+	})
+
+	key := cmd.String(cli.StringArg{
+		Name: "KEY",
+		Desc: "the configuration key",
+	})
+
+	cmd.Action = func() {
+		client, err := NewClient()
+		if err != nil {
+			log.Fatal(err)
+		}
+		if err := client.Project.Env.UnsetEnv(*pid, *key); err != nil {
+			log.Fatal(err)
+		}
+	}
+}

--- a/client/client.go
+++ b/client/client.go
@@ -27,6 +27,7 @@ func New(config *Config) (*Client, error) {
 			config: config,
 			Key:    &ProjectKey{config},
 			Config: &ProjectConfig{config},
+			Env:    &ProjectEnv{config},
 		},
 		Job:     &Job{config},
 		Variant: &Variant{config},

--- a/client/project.go
+++ b/client/project.go
@@ -12,6 +12,7 @@ type Project struct {
 	config *Config
 	Key    *ProjectKey
 	Config *ProjectConfig
+	Env    *ProjectEnv
 }
 
 func (c *Project) List() ([]lib.Project, error) {

--- a/client/project_env.go
+++ b/client/project_env.go
@@ -1,0 +1,52 @@
+package client
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/racker/perigee"
+)
+
+type ProjectEnv struct {
+	config *Config
+}
+
+func (c *ProjectEnv) Get(id string) (map[string]string, error) {
+	var res map[string]string
+
+	requestURL, err := c.config.getRequestURL(fmt.Sprintf("project/%s/env", id))
+	if err != nil {
+		return nil, err
+	}
+
+	err = perigee.Get(requestURL, perigee.Options{
+		Results:    &res,
+		OkCodes:    []int{200},
+		SetHeaders: c.config.authenticateRequest,
+	})
+	return res, err
+}
+
+func (c *ProjectEnv) SetEnv(id, key, value string) error {
+	requestURL, err := c.config.getRequestURL(fmt.Sprintf("project/%s/env/%s", id, key))
+	if err != nil {
+		return err
+	}
+	return perigee.Put(requestURL, perigee.Options{
+		ContentType: "text/plain",
+		ReqBody:     strings.NewReader(value),
+		OkCodes:     []int{204},
+		SetHeaders:  c.config.authenticateRequest,
+	})
+}
+
+func (c *ProjectEnv) UnsetEnv(id, key string) error {
+	requestURL, err := c.config.getRequestURL(fmt.Sprintf("project/%s/env/%s", id, key))
+	if err != nil {
+		return err
+	}
+	return perigee.Delete(requestURL, perigee.Options{
+		OkCodes:    []int{204},
+		SetHeaders: c.config.authenticateRequest,
+	})
+}

--- a/commons/config.go
+++ b/commons/config.go
@@ -3,6 +3,7 @@ package bazooka
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
 const (
@@ -40,6 +41,14 @@ type ConfigMatrix struct {
 	Exclude []map[string]interface{} `yaml:"exclude,omitempty"`
 }
 
+func FlattenStringsEnvMap(mapp map[string]string) []string {
+	res := []string{}
+	for key, value := range mapp {
+		res = append(res, fmt.Sprintf("%s=%s", key, value))
+	}
+	return res
+}
+
 func ResolveConfigFile(source string) (string, error) {
 	bazookaPath := fmt.Sprintf("%s/%s", source, bazookaConfigFile)
 	exist, err := FileExists(bazookaPath)
@@ -74,4 +83,17 @@ func (c *Commands) UnmarshalYAML(unmarshal func(interface{}) error) (err error) 
 func (g *Globs) UnmarshalYAML(unmarshal func(interface{}) error) (err error) {
 	*g, err = unmarshalOneOrMany(unmarshal, "Globs (archive, archive_success, archive_failure)")
 	return err
+}
+
+func GetStringsEnvMap(envArray []string) map[string][]string {
+	envKeyMap := make(map[string][]string)
+	for _, env := range envArray {
+		envSplit := strings.Split(env, "=")
+		value := ""
+		if len(envSplit) == 2 {
+			value = envSplit[1]
+		}
+		envKeyMap[envSplit[0]] = append(envKeyMap[envSplit[0]], value)
+	}
+	return envKeyMap
 }

--- a/commons/mongo/project.go
+++ b/commons/mongo/project.go
@@ -107,6 +107,30 @@ func (c *MongoConnector) AddProject(project *lib.Project) error {
 }
 
 func (c *MongoConnector) SetProjectConfig(id string, config map[string]string) error {
+	return c.setProjectDatastore("config", id, config)
+}
+
+func (c *MongoConnector) SetProjectConfigKey(id, key, value string) error {
+	return c.setProjectDatastoreKey("config", id, key, value)
+}
+
+func (c *MongoConnector) UnsetProjectConfigKey(id, key string) error {
+	return c.unsetProjectDatastoreKey("config", id, key)
+}
+
+func (c *MongoConnector) SetProjectEnv(id string, config map[string]string) error {
+	return c.setProjectDatastore("env", id, config)
+}
+
+func (c *MongoConnector) SetProjectEnvKey(id, key, value string) error {
+	return c.setProjectDatastoreKey("env", id, key, value)
+}
+
+func (c *MongoConnector) UnsetProjectEnvKey(id, key string) error {
+	return c.unsetProjectDatastoreKey("env", id, key)
+}
+
+func (c *MongoConnector) setProjectDatastore(datastore string, id string, config map[string]string) error {
 	proj, err := c.GetProjectById(id)
 	if err != nil {
 		return err
@@ -120,13 +144,13 @@ func (c *MongoConnector) SetProjectConfig(id string, config map[string]string) e
 	}
 	request := bson.M{
 		"$set": bson.M{
-			"config": escapedConfig,
+			datastore: escapedConfig,
 		},
 	}
 	return c.database.C("projects").Update(selector, request)
 }
 
-func (c *MongoConnector) SetProjectConfigKey(id, key, value string) error {
+func (c *MongoConnector) setProjectDatastoreKey(datastore, id, key, value string) error {
 	proj, err := c.GetProjectById(id)
 	if err != nil {
 		return err
@@ -136,13 +160,13 @@ func (c *MongoConnector) SetProjectConfigKey(id, key, value string) error {
 	}
 	request := bson.M{
 		"$set": bson.M{
-			fmt.Sprintf("config.%s", escapeDots(key)): value,
+			fmt.Sprintf("%s.%s", datastore, escapeDots(key)): value,
 		},
 	}
 	return c.database.C("projects").Update(selector, request)
 }
 
-func (c *MongoConnector) UnsetProjectConfigKey(id, key string) error {
+func (c *MongoConnector) unsetProjectDatastoreKey(datastore, id, key string) error {
 	proj, err := c.GetProjectById(id)
 	if err != nil {
 		return err
@@ -152,7 +176,7 @@ func (c *MongoConnector) UnsetProjectConfigKey(id, key string) error {
 	}
 	request := bson.M{
 		"$unset": bson.M{
-			fmt.Sprintf("config.%s", escapeDots(key)): "",
+			fmt.Sprintf("%s.%s", datastore, escapeDots(key)): "",
 		},
 	}
 	return c.database.C("projects").Update(selector, request)

--- a/commons/project.go
+++ b/commons/project.go
@@ -10,6 +10,7 @@ type Project struct {
 	HookKey    string            `bson:"hook_key" json:"hook_key"`
 	JobCounter int               `bson:"job_counter" json:"job_counter"`
 	Config     map[string]string `bson:"config" json:"config"`
+	Env        map[string]string `bson:"env" json:"env"`
 }
 
 type ProjectWithStatus struct {

--- a/server/main.go
+++ b/server/main.go
@@ -77,6 +77,10 @@ func main() {
 	r.HandleFunc("/project/{id}/key", ctx.mkAuthHandler(ctx.updateKey)).Methods("PUT")
 	r.HandleFunc("/project/{id}/key", ctx.mkAuthHandler(ctx.listKeys)).Methods("GET")
 
+	r.HandleFunc("/project/{id}/env", ctx.mkAuthHandler(ctx.getProjectEnv)).Methods("GET")
+	r.HandleFunc("/project/{id}/env/{key}", ctx.mkAuthHandler(ctx.setProjectEnvKey)).Methods("PUT")
+	r.HandleFunc("/project/{id}/env/{key}", ctx.mkAuthHandler(ctx.unsetProjectEnvKey)).Methods("DELETE")
+
 	r.HandleFunc("/project/{id}/crypto", ctx.mkAuthHandler(ctx.encryptData)).Methods("PUT")
 
 	r.HandleFunc("/job", ctx.mkAuthHandler(ctx.getAllJobs)).Methods("GET")


### PR DESCRIPTION
Enable job parameters to be set on project side.

Can be use to defined default parameters values.

Add a new command: `bzk project env`

```
Usage: bzk project env  COMMAND [arg...]

View or modify a bazooka project environment variable

Commands:
  list         List project environment variables
  get          Get a specific project environment variable
  set          Set a specific project environment variable
  unset        Delete a specific project configuration key
```

`bzk project env my-project A 5` sets the default value of A to 5 for the project my-project. This value is used if a job is started without specify a value for A.

Permutation is not yet possible (wip, it'll come on another PR). Permutations can only be generated by using `bzk job start` command.