### PR TITLE
Rewrite bzk service

### DIFF
--- a/cli/bzk/config.go
+++ b/cli/bzk/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	DockerSock string `yaml:"docker_sock"`
 	SCMKey     string `yaml:"scm_key"`
 	Registry   string `yaml:"registry"`
+	Tag        string `yaml:"tag"`
 
 	MongoURI string `yaml:"mongo_uri"`
 }


### PR DESCRIPTION
- bzk service restart == bzk service stop && bzk service start
- Rename tag option by version on bzk service start
- Add --recreate options on bzk service restart which destroy container before restarting it

```
Usage: bzk service restart [--recreate [-swd]]

Restart bazooka

Options:
  --recreate        Recreate existing Bazooka containers
  -s, --server      Recreate existing server container
  -w, --web         Recreate existing web container
  -d, --database    Recreate existing database container
```

https://github.com/bywan/go-dockercommand/pull/8 is required.

