### PR TITLE
Tweak SCM key handling

### DIFF
--- a/cli/bzk/bzk.go
+++ b/cli/bzk/bzk.go
@@ -40,9 +40,8 @@ func main() {
 	})
 
 	app.Command("key", "Actions on projects keys", func(cmd *cli.Cmd) {
-		cmd.Command("list", "list Keys for the bazooka project", listKeysCommand)
-		cmd.Command("add", "Add SSH Key for the bazooka project", addKeyCommand)
-		cmd.Command("update", "Update SSH Key for the bazooka project", updateKeyCommand)
+		cmd.Command("get", "list Keys for the bazooka project", getKeyCommand)
+		cmd.Command("set", "Add SSH Key for the bazooka project", setKeyCommand)
 	})
 
 	app.Command("image", "Actions on images", func(cmd *cli.Cmd) {

--- a/cli/bzk/key.go
+++ b/cli/bzk/key.go
@@ -9,7 +9,7 @@ import (
 	"github.com/jawher/mow.cli"
 )
 
-func addKeyCommand(cmd *cli.Cmd) {
+func setKeyCommand(cmd *cli.Cmd) {
 	pid := cmd.String(cli.StringArg{
 		Name: "PROJECT_ID",
 		Desc: "Project id",
@@ -24,44 +24,13 @@ func addKeyCommand(cmd *cli.Cmd) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		res, err := client.Project.Key.Add(*pid, *scmKey)
-		if err != nil {
+		if err := client.Project.Key.Set(*pid, *scmKey); err != nil {
 			log.Fatal(err)
 		}
-		w := tabwriter.NewWriter(os.Stdout, 15, 1, 3, ' ', 0)
-		fmt.Fprint(w, "PROJECT ID\n")
-		fmt.Fprintf(w, "%s\n", idExcerpt(res.ProjectID))
-		w.Flush()
 	}
 }
 
-func updateKeyCommand(cmd *cli.Cmd) {
-	pid := cmd.String(cli.StringArg{
-		Name: "PROJECT_ID",
-		Desc: "Project id",
-	})
-	scmKey := cmd.String(cli.StringArg{
-		Name: "SCM_KEY_PATH",
-		Desc: "The absolute path to the SCM key",
-	})
-
-	cmd.Action = func() {
-		client, err := NewClient()
-		if err != nil {
-			log.Fatal(err)
-		}
-		res, err := client.Project.Key.Update(*pid, *scmKey)
-		if err != nil {
-			log.Fatal(err)
-		}
-		w := tabwriter.NewWriter(os.Stdout, 15, 1, 3, ' ', 0)
-		fmt.Fprint(w, "PROJECT ID\n")
-		fmt.Fprintf(w, "%s\n", idExcerpt(res.ProjectID))
-		w.Flush()
-	}
-}
-
-func listKeysCommand(cmd *cli.Cmd) {
+func getKeyCommand(cmd *cli.Cmd) {
 	pid := cmd.String(cli.StringArg{
 		Name: "PROJECT_ID",
 		Desc: "Project id",
@@ -72,15 +41,13 @@ func listKeysCommand(cmd *cli.Cmd) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		res, err := client.Project.Key.List(*pid)
+		res, err := client.Project.Key.Get(*pid)
 		if err != nil {
 			log.Fatal(err)
 		}
 		w := tabwriter.NewWriter(os.Stdout, 15, 1, 3, ' ', 0)
 		fmt.Fprint(w, "PROJECT ID\n")
-		for _, item := range res {
-			fmt.Fprintf(w, "%s\n", idExcerpt(item.ProjectID))
-		}
+		fmt.Fprintf(w, "%s\n", idExcerpt(res.ProjectID))
 		w.Flush()
 	}
 }

--- a/cli/bzk/project.go
+++ b/cli/bzk/project.go
@@ -39,8 +39,7 @@ func createProjectCommand(cmd *cli.Cmd) {
 			log.Fatal(err)
 		}
 		if len(*scmKey) > 0 {
-			_, err = client.Project.Key.Add(res.ID, *scmKey)
-			if err != nil {
+			if err = client.Project.Key.Set(res.ID, *scmKey); err != nil {
 				log.Fatal(err)
 			}
 		}

--- a/client/project_key.go
+++ b/client/project_key.go
@@ -13,9 +13,8 @@ type ProjectKey struct {
 	config *Config
 }
 
-func (c *ProjectKey) List(projectID string) ([]*lib.SSHKey, error) {
-
-	var keys []*lib.SSHKey
+func (c *ProjectKey) Get(projectID string) (*lib.SSHKey, error) {
+	var key lib.SSHKey
 
 	requestURL, err := c.config.getRequestURL(fmt.Sprintf("project/%s/key", url.QueryEscape(projectID)))
 	if err != nil {
@@ -23,18 +22,18 @@ func (c *ProjectKey) List(projectID string) ([]*lib.SSHKey, error) {
 	}
 
 	err = perigee.Get(requestURL, perigee.Options{
-		Results:    &keys,
+		Results:    &key,
 		OkCodes:    []int{200},
 		SetHeaders: c.config.authenticateRequest,
 	})
 
-	return keys, err
+	return &key, err
 }
 
-func (c *ProjectKey) Add(projectID, keyPath string) (*lib.SSHKey, error) {
+func (c *ProjectKey) Set(projectID, keyPath string) error {
 	fileContent, err := ioutil.ReadFile(keyPath)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	sshKey := &lib.SSHKey{
@@ -44,45 +43,14 @@ func (c *ProjectKey) Add(projectID, keyPath string) (*lib.SSHKey, error) {
 
 	requestURL, err := c.config.getRequestURL(fmt.Sprintf("project/%s/key", url.QueryEscape(projectID)))
 	if err != nil {
-		return nil, err
+		return err
 	}
-
-	createdKey := &lib.SSHKey{}
-
-	err = perigee.Post(requestURL, perigee.Options{
-		ReqBody:    &sshKey,
-		Results:    &createdKey,
-		OkCodes:    []int{201},
-		SetHeaders: c.config.authenticateRequest,
-	})
-
-	return createdKey, err
-}
-
-func (c *ProjectKey) Update(projectID, keyPath string) (*lib.SSHKey, error) {
-	fileContent, err := ioutil.ReadFile(keyPath)
-	if err != nil {
-		return nil, err
-	}
-
-	sshKey := &lib.SSHKey{
-		ProjectID: projectID,
-		Content:   string(fileContent),
-	}
-
-	requestURL, err := c.config.getRequestURL(fmt.Sprintf("project/%s/key", url.QueryEscape(projectID)))
-	if err != nil {
-		return nil, err
-	}
-
-	updatedKey := &lib.SSHKey{}
 
 	err = perigee.Put(requestURL, perigee.Options{
 		ReqBody:    &sshKey,
-		Results:    &updatedKey,
-		OkCodes:    []int{200},
+		OkCodes:    []int{204},
 		SetHeaders: c.config.authenticateRequest,
 	})
 
-	return updatedKey, err
+	return err
 }

--- a/commons/mongo/connector.go
+++ b/commons/mongo/connector.go
@@ -62,10 +62,10 @@ func (c *MongoConnector) Close() {
 	c.session.Close()
 }
 
-func (m *MongoConnector) idLike(id string) bson.M {
+func (m *MongoConnector) fieldStartsWith(field, value string) bson.M {
 	return bson.M{
-		"id": bson.M{
-			"$regex":   "^" + id,
+		field: bson.M{
+			"$regex":   "^" + value,
 			"$options": "i",
 		},
 	}
@@ -80,7 +80,7 @@ func (m *MongoConnector) randomId() (string, error) {
 	return fmt.Sprintf("%x%x%x%x%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:]), nil
 }
 
-func (m *MongoConnector) ByField(collection, fieldName string, fieldValue string, result interface{}) error {
+func (m *MongoConnector) selectOneByField(collection, fieldName string, fieldValue string, result interface{}) error {
 	q := m.database.C(collection).Find(bson.M{fieldName: fieldValue})
 	count, err := q.Count()
 	if err != nil {
@@ -97,32 +97,31 @@ func (m *MongoConnector) ByField(collection, fieldName string, fieldValue string
 	}
 }
 
-func (m *MongoConnector) ById(collection, id string, result interface{}) error {
-	q := m.database.C(collection).Find(m.idLike(id))
+func (m *MongoConnector) selectOneByFieldLike(collection, fieldName string, fieldValue string, result interface{}) error {
+	q := m.database.C(collection).Find(m.fieldStartsWith(fieldName, fieldValue))
 	count, err := q.Count()
 	if err != nil {
 		return err
 	}
 	switch count {
 	case 0:
-		return &NotFoundError{collection, "id", id}
+		return &NotFoundError{collection, fieldName, fieldValue}
 	case 1:
 		return q.One(result)
 
 	default:
-		return &ManyFoundError{collection, "id", id, count}
+		return &ManyFoundError{collection, fieldName, fieldValue, count}
 	}
 }
 
-func (m *MongoConnector) ByIdOrName(collection, id string, result interface{}) error {
-	err := m.ById(collection, id, result)
+func (m *MongoConnector) selectOneByIdOrName(collection, id string, result interface{}) error {
+	err := m.selectOneByFieldLike(collection, "id", id, result)
 	switch err.(type) {
 	case *NotFoundError:
-		return m.ByField(collection, "name", id, result)
+		return m.selectOneByField(collection, "name", id, result)
 	default:
 		return err
 	}
-
 }
 
 func getMongoUri() string {

--- a/commons/mongo/crypto.go
+++ b/commons/mongo/crypto.go
@@ -7,7 +7,7 @@ import (
 
 func (c *MongoConnector) GetProjectCryptoKey(projectID string) (*bazooka.CryptoKey, error) {
 	result := &bazooka.CryptoKey{}
-	if err := c.ByField("crypto", "project_id", projectID, result); err != nil {
+	if err := c.selectOneByField("crypto", "project_id", projectID, result); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/commons/mongo/key.go
+++ b/commons/mongo/key.go
@@ -6,39 +6,26 @@ import (
 )
 
 func (c *MongoConnector) GetProjectKey(projectID string) (*lib.SSHKey, error) {
-	result := &lib.SSHKey{}
-	if err := c.ByField("keys", "project_id", projectID, result); err != nil {
-		return nil, err
-	}
-	return result, nil
-}
-
-func (c *MongoConnector) UpdateKey(id string, key *lib.SSHKey) error {
-	return c.database.C("keys").Update(bson.M{
-		"project_id": id,
-	}, key)
-}
-
-func (c *MongoConnector) AddKey(key *lib.SSHKey) error {
-	var err error
-	if key.ID, err = c.randomId(); err != nil {
-		return err
-	}
-
-	return c.database.C("keys").Insert(key)
-}
-
-func (c *MongoConnector) GetKeys(projectID string) ([]*lib.SSHKey, error) {
 	proj, err := c.GetProjectById(projectID)
 	if err != nil {
 		return nil, err
 	}
 
-	result := []*lib.SSHKey{}
+	result := &lib.SSHKey{}
+	if err := c.selectOneByField("keys", "project_id", proj.ID, result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
 
-	err = c.database.C("keys").Find(bson.M{
+func (c *MongoConnector) SetProjectKey(projectID string, key *lib.SSHKey) error {
+	proj, err := c.GetProjectById(projectID)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.database.C("keys").Upsert(bson.M{
 		"project_id": proj.ID,
-	}).All(&result)
-
-	return result, err
+	}, key)
+	return err
 }

--- a/commons/mongo/project.go
+++ b/commons/mongo/project.go
@@ -27,7 +27,7 @@ func (c *MongoConnector) HasProject(name string) (bool, error) {
 
 func (c *MongoConnector) GetProjectById(id string) (*lib.Project, error) {
 	result := &lib.Project{}
-	if err := c.ByIdOrName("projects", id, result); err != nil {
+	if err := c.selectOneByIdOrName("projects", id, result); err != nil {
 		return nil, err
 	}
 	result.Config = unescapeDotsInMap(result.Config)
@@ -339,7 +339,7 @@ func (c *MongoConnector) FinishJob(id string, status lib.JobStatus, completed ti
 			"completed": completed,
 		},
 	}
-	return c.database.C("jobs").Update(c.idLike(id), request)
+	return c.database.C("jobs").Update(c.fieldStartsWith("id", id), request)
 }
 
 func (c *MongoConnector) AddJobSCMMetadata(id string, metadata *lib.SCMMetadata) error {
@@ -372,12 +372,12 @@ func (c *MongoConnector) FinishVariant(id string, status lib.JobStatus, complete
 			"artifacts": artifacts,
 		},
 	}
-	return c.database.C("variants").Update(c.idLike(id), request)
+	return c.database.C("variants").Update(c.fieldStartsWith("id", id), request)
 }
 
 func (c *MongoConnector) GetJobByID(id string) (*lib.Job, error) {
 	result := &lib.Job{}
-	if err := c.ById("jobs", id, result); err != nil {
+	if err := c.selectOneByFieldLike("jobs", "id", id, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -385,7 +385,7 @@ func (c *MongoConnector) GetJobByID(id string) (*lib.Job, error) {
 
 func (c *MongoConnector) GetVariantByID(id string) (*lib.Variant, error) {
 	result := &lib.Variant{}
-	if err := c.ById("variants", id, result); err != nil {
+	if err := c.selectOneByFieldLike("variants", "id", id, result); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/commons/mongo/user.go
+++ b/commons/mongo/user.go
@@ -11,7 +11,7 @@ import (
 
 func (c *MongoConnector) GetUserByEmail(email string) (*lib.User, error) {
 	result := &lib.User{}
-	if err := c.ByField("user", "email", email, result); err != nil {
+	if err := c.selectOneByField("user", "email", email, result); err != nil {
 		return nil, err
 	}
 	result.Password = ""
@@ -63,7 +63,7 @@ func (c *MongoConnector) AddUser(user *lib.User) error {
 
 func (c *MongoConnector) ComparePassword(email string, password string) bool {
 	result := &lib.User{}
-	if err := c.ByField("user", "email", email, result); err != nil {
+	if err := c.selectOneByField("user", "email", email, result); err != nil {
 		return false
 	}
 

--- a/server/keys.go
+++ b/server/keys.go
@@ -3,52 +3,10 @@ package main
 import (
 	log "github.com/Sirupsen/logrus"
 	lib "github.com/bazooka-ci/bazooka/commons"
+	"github.com/bazooka-ci/bazooka/commons/mongo"
 )
 
-func (c *context) addKey(r *request) (*response, error) {
-	var key lib.SSHKey
-
-	r.parseBody(&key)
-
-	if len(key.Content) == 0 {
-		return badRequest("content is mandatory")
-	}
-
-	project, err := c.connector.GetProjectById(r.vars["id"])
-	if err != nil {
-		if err.Error() != "not found" {
-			return nil, err
-		}
-		return notFound("project not found")
-	}
-
-	keys, err := c.connector.GetKeys(r.vars["id"])
-	if err != nil {
-		return nil, err
-	}
-
-	if len(keys) > 0 {
-		return conflict("A key is already associated with this project")
-	}
-
-	key.ProjectID = project.ID
-
-	log.WithFields(log.Fields{
-		"key": key,
-	}).Debug("Adding key")
-
-	if err = c.connector.AddKey(&key); err != nil {
-		return nil, err
-	}
-
-	createdKey := &lib.SSHKey{
-		ProjectID: key.ProjectID,
-	}
-
-	return created(&createdKey, "/project/"+r.vars["id"]+"/key")
-}
-
-func (c *context) updateKey(r *request) (*response, error) {
+func (c *context) setKey(r *request) (*response, error) {
 	var key lib.SSHKey
 
 	r.parseBody(&key)
@@ -69,25 +27,23 @@ func (c *context) updateKey(r *request) (*response, error) {
 
 	log.WithFields(log.Fields{
 		"key": key,
-	}).Debug("Updating key")
+	}).Debug("Setting key")
 
-	if err = c.connector.UpdateKey(project.ID, &key); err != nil {
+	if err = c.connector.SetProjectKey(project.ID, &key); err != nil {
 		return nil, err
 	}
 
-	updateKey := &lib.SSHKey{
-		ProjectID: key.ProjectID,
-	}
-
-	return ok(&updateKey)
+	return noContent()
 }
 
-func (c *context) listKeys(r *request) (*response, error) {
-
-	keys, err := c.connector.GetKeys(r.vars["id"])
+func (c *context) getKey(r *request) (*response, error) {
+	key, err := c.connector.GetProjectKey(r.vars["id"])
 	if err != nil {
+		if _, ok := err.(*mongo.NotFoundError); ok {
+			return notFound("key not found")
+		}
 		return nil, err
 	}
 
-	return ok(&keys)
+	return ok(&key)
 }

--- a/server/main.go
+++ b/server/main.go
@@ -38,9 +38,8 @@ func main() {
 	r.HandleFunc("/project/{id}/config/{key}", context.mkAuthHandler(context.setProjectConfigKey)).Methods("PUT")
 	r.HandleFunc("/project/{id}/config/{key}", context.mkAuthHandler(context.unsetProjectConfigKey)).Methods("DELETE")
 
-	r.HandleFunc("/project/{id}/key", context.mkAuthHandler(context.addKey)).Methods("POST")
-	r.HandleFunc("/project/{id}/key", context.mkAuthHandler(context.updateKey)).Methods("PUT")
-	r.HandleFunc("/project/{id}/key", context.mkAuthHandler(context.listKeys)).Methods("GET")
+	r.HandleFunc("/project/{id}/key", context.mkAuthHandler(context.setKey)).Methods("PUT")
+	r.HandleFunc("/project/{id}/key", context.mkAuthHandler(context.getKey)).Methods("GET")
 
 	r.HandleFunc("/project/{id}/crypto", context.mkAuthHandler(context.encryptData)).Methods("PUT")
 


### PR DESCRIPTION
The API (and therefore the CLI) now only exposes 2 operations: get and set an SCM key on a project.

This PR also includes a bit of cleanup/refactoring on the mongo db code.