### PR TITLE
Add a 5 second grace period when stopping the bazooka containers

### DIFF
--- a/cli/bzk/service.go
+++ b/cli/bzk/service.go
@@ -403,6 +403,7 @@ func stopContainer(client *docker.Docker, name string, allContainers []dockercli
 		fmt.Printf("Stopping Container %s\n", name)
 		err = client.Stop(&docker.StopOptions{
 			ID: container.ID,
+			Timeout: 5,
 		})
 		if err != nil {
 			return fmt.Errorf("Error stopping container %s, reason is %v\n", name, err)

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,6 +2,6 @@ FROM busybox:ubuntu-14.04
 
 COPY main /bin/main
 
-ENTRYPOINT /bin/main
+ENTRYPOINT ["/bin/main"]
 
 EXPOSE 3000

--- a/server/main.go
+++ b/server/main.go
@@ -4,6 +4,11 @@ import (
 	"fmt"
 	"net/http"
 
+	"os"
+	"os/signal"
+
+	"syscall"
+
 	log "github.com/Sirupsen/logrus"
 	bzklog "github.com/bazooka-ci/bazooka/commons/logs"
 	"github.com/bazooka-ci/bazooka/commons/mongo"
@@ -65,7 +70,14 @@ func main() {
 
 	http.Handle("/", r)
 
-	log.Fatal(http.ListenAndServe(":3000", nil))
+	go func() {
+		log.Fatal(http.ListenAndServe(":3000", nil))
+	}()
+
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGTERM)
+	<-signals
+	log.Infof("Got SIGTERM, Exiting")
 }
 
 var (


### PR DESCRIPTION
In order to fix spurious mongoldb data corruption which can occur with no grace.

The server component was also modified to listen to and handle the SIGTERM signal docker sends to containers when stopping them, to avoid blocking for the duration of the grace period before stopping.