### PR TITLE
Use syslog to capture the build log

### DIFF
--- a/cli/bzk/config.go
+++ b/cli/bzk/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	Auth     string `yaml:"auth"`
 
 	ServerURI  string `yaml:"server_uri"`
+	SyslogURI  string `yaml:"syslog_uri"`
 	Home       string `yaml:"home"`
 	DockerSock string `yaml:"docker_sock"`
 	SCMKey     string `yaml:"scm_key"`

--- a/commons/log.go
+++ b/commons/log.go
@@ -1,0 +1,45 @@
+package bazooka
+
+import (
+	"regexp"
+	"strings"
+	"time"
+)
+
+var (
+	regLogLevel = regexp.MustCompile(`^\s*\[(\S+)\].*$`)      // Eg. [INFO] My message
+	regMeta     = regexp.MustCompile(`^\s*\<(\S+):(.*)>\s*$`) // Eg. <CMD:go test -v ./...>
+)
+
+func ConstructLog(message string, template LogEntry) LogEntry {
+	message = strings.TrimSpace(message)
+
+	switch {
+	case regLogLevel.MatchString(message):
+		submatchs := regLogLevel.FindStringSubmatch(message)
+		logLevel := submatchs[len(submatchs)-1]
+		template.Level = logLevel
+		template.Message = strings.TrimSpace(message[len(logLevel)+2:])
+	case regMeta.MatchString(message):
+		submatchs := regMeta.FindStringSubmatch(message)
+		instructionType := submatchs[1]
+		instructionValue := submatchs[2]
+		switch instructionType {
+		case "CMD":
+			template.Command = instructionValue
+			template.Message = ""
+		case "PHASE":
+			template.Phase = instructionValue
+			template.Message = ""
+		default:
+			template.Message = message
+		}
+	default:
+		template.Message = message
+	}
+
+	if template.Time.IsZero() {
+		template.Time = time.Now()
+	}
+	return template
+}

--- a/commons/syslogparser/syslog.go
+++ b/commons/syslogparser/syslog.go
@@ -1,0 +1,136 @@
+package syslogparser
+
+import (
+	"fmt"
+	"log/syslog"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Message struct {
+	Priority  syslog.Priority
+	Facility  syslog.Priority
+	Severity  syslog.Priority
+	Timestamp time.Time
+	Host      string
+	Meta      map[string]string
+	Pid       int
+	Content   string
+}
+
+const (
+	severityMask = 0x07
+	facilityMask = 0xf8
+)
+
+func Parse(line []byte) (*Message, error) {
+	return (&parser{string(line), 0}).parse()
+}
+
+type parser struct {
+	line string
+	pos  int
+}
+
+func (p *parser) parse() (msg *Message, err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			msg = nil
+			err = fmt.Errorf("%s\n%s^ %v\n", p.line, strings.Repeat(" ", p.pos), e)
+		}
+	}()
+	p.line = strings.TrimSuffix(p.line, "\n")
+	err = nil
+	msg = &Message{}
+	p.expect("<")
+	{
+		rawPri := p.until(">", "priority")
+		pri, err := strconv.Atoi(rawPri)
+		if err != nil {
+			return nil, fmt.Errorf("Invalid priority %s", rawPri)
+		}
+
+		msg.Priority = syslog.Priority(pri)
+		msg.Facility = syslog.Priority(pri & facilityMask)
+		msg.Severity = syslog.Priority(pri & severityMask)
+	}
+
+	{
+		ts := p.until(" ", "timestamp")
+		parsedTimestamp, err := time.Parse(time.RFC3339, ts)
+		if err != nil {
+			return nil, err
+		}
+		msg.Timestamp = parsedTimestamp
+	}
+
+	{
+		msg.Host = p.until(" ", "host")
+	}
+
+	{
+		msg.Meta = map[string]string{}
+
+		tag := p.until("[", "tag")
+		elfAndMeta := strings.SplitN(tag, "/", 2)
+		meta := elfAndMeta[1]
+		kvs := strings.Split(meta, ";")
+		for _, kv := range kvs {
+			a := strings.Split(kv, "=")
+			msg.Meta[a[0]] = a[1]
+		}
+	}
+
+	{
+		rawPid := p.until("]", "pid")
+		pid, err := strconv.Atoi(rawPid)
+		if err != nil {
+			return nil, fmt.Errorf("Invalid pid: %s", rawPid)
+		}
+		msg.Pid = pid
+	}
+
+	p.expect(": ")
+	msg.Content = p.line[p.pos:]
+	return
+}
+
+func (p *parser) until(end, name string) string {
+	pos0 := p.pos
+	for !p.eof() {
+		if !strings.HasPrefix(p.line[p.pos:], end) {
+			p.pos++
+			continue
+		}
+		break
+	}
+	if pos0 == p.pos {
+		panic(fmt.Sprintf("Missing %s", name))
+	}
+
+	res := p.line[pos0:p.pos]
+	if !p.eof() {
+		p.pos++
+	}
+	return res
+}
+
+func (p *parser) eof() bool {
+	return p.pos >= len(p.line)
+}
+
+func (p *parser) found(s string) bool {
+	if strings.HasPrefix(p.line[p.pos:], s) {
+		p.pos += len(s)
+		return true
+	}
+	return false
+}
+
+func (p *parser) expect(s string) {
+	if p.found(s) {
+		return
+	}
+	panic(fmt.Sprintf("Was expecting '%s' but got '%s", s, p.line[p.pos:]))
+}

--- a/commons/syslogparser/syslog_test.go
+++ b/commons/syslogparser/syslog_test.go
@@ -1,0 +1,28 @@
+package syslogparser
+
+import (
+	"github.com/stretchr/testify/require"
+
+	"log/syslog"
+	"testing"
+	"time"
+)
+
+func TestParse(t *testing.T) {
+	msg, err := Parse([]byte("<27>2015-06-07T16:12:49Z jessie-amd64 docker-1.7.0-dev/image=bazooka/scm-git;project=pid;job=jid[4432]: Warning: Permanently added 'bitbucket.org,131.103.20.16"))
+	require.NoError(t, err, "Should parse")
+
+	require.Equal(t, syslog.Priority(27), msg.Priority)
+	require.Equal(t, syslog.Priority(24), msg.Facility)
+	require.Equal(t, syslog.Priority(3), msg.Severity)
+	ts, _ := time.Parse("2006-01-02T15:04:05", "2015-06-07T16:12:49")
+	require.Equal(t, ts, msg.Timestamp)
+	require.Equal(t, "jessie-amd64", msg.Host)
+	require.Equal(t, map[string]string{
+		"project": "pid",
+		"job":     "jid",
+		"image":   "bazooka/scm-git",
+	}, msg.Meta)
+	require.Equal(t, 4432, msg.Pid)
+	require.Equal(t, "Warning: Permanently added 'bitbucket.org,131.103.20.16", msg.Content)
+}

--- a/orchestration/scmfectch.go
+++ b/orchestration/scmfectch.go
@@ -13,7 +13,7 @@ type SCMFetcher struct {
 	update  bool
 }
 
-func (f *SCMFetcher) Fetch(logger Logger) error {
+func (f *SCMFetcher) Fetch() error {
 	log.WithFields(log.Fields{
 		"source": f.context.scmUrl,
 	}).Info("Fetching SCM From Source Repository")
@@ -54,17 +54,16 @@ func (f *SCMFetcher) Fetch(logger Logger) error {
 	}
 
 	container, err := client.Run(&docker.RunOptions{
-		Image:       image,
-		VolumeBinds: volumes,
-		Env:         env,
-		Detach:      true,
+		Image:               image,
+		VolumeBinds:         volumes,
+		Env:                 env,
+		Detach:              true,
+		LoggingDriver:       "syslog",
+		LoggingDriverConfig: f.context.loggerConfig(image, ""),
 	})
 	if err != nil {
 		return err
 	}
-
-	container.Logs(image)
-	logger(image, "", container)
 
 	exitCode, err := container.Wait()
 	if err != nil {

--- a/parser/context.go
+++ b/parser/context.go
@@ -4,10 +4,13 @@ import (
 	"encoding/json"
 	"os"
 
+	"fmt"
+
 	lib "github.com/bazooka-ci/bazooka/commons"
 )
 
 const (
+	BazookaEnvSyslogUrl     = "BZK_SYSLOG_URL"
 	BazookaEnvHome          = "BZK_HOME"
 	BazookaEnvSrc           = "BZK_SRC"
 	BazookaEnvCryptoKeyfile = "BZK_CRYPTO_KEYFILE"
@@ -17,6 +20,7 @@ const (
 )
 
 type context struct {
+	syslogUrl     string
 	projectID     string
 	jobID         string
 	jobParameters string
@@ -39,6 +43,7 @@ type path struct {
 
 func initContext() *context {
 	return &context{
+		syslogUrl:     os.Getenv(BazookaEnvSyslogUrl),
 		projectID:     os.Getenv(BazookaEnvProjectID),
 		jobID:         os.Getenv(BazookaEnvJobID),
 		jobParameters: os.Getenv(BazookaEnvJobParameters),
@@ -50,6 +55,13 @@ func initContext() *context {
 			dockerSock:     path{"/var/run/docker.sock", ""},
 			dockerEndpoint: path{"unix:///var/run/docker.sock", ""},
 		},
+	}
+}
+
+func (c *context) loggerConfig(image string) map[string]string {
+	return map[string]string{
+		"syslog-address": c.syslogUrl,
+		"syslog-tag":     fmt.Sprintf("image=%s;project=%s;job=%s", image, c.projectID, c.jobID),
 	}
 }
 

--- a/parser/language_parser.go
+++ b/parser/language_parser.go
@@ -40,7 +40,9 @@ func (p *LanguageParser) Parse() ([]*variantData, error) {
 			fmt.Sprintf("%s:/meta", paths.meta.host),
 			fmt.Sprintf("%s:/bazooka-cryptokey", paths.cryptoKey.host),
 		},
-		Detach: true,
+		Detach:              true,
+		LoggingDriver:       "syslog",
+		LoggingDriverConfig: p.context.loggerConfig(p.image),
 	})
 	if err != nil {
 		return nil, err

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -4,4 +4,4 @@ COPY main /bin/main
 
 ENTRYPOINT ["/bin/main"]
 
-EXPOSE 3000
+EXPOSE 3000 3001

--- a/server/context.go
+++ b/server/context.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"time"
 
+	"fmt"
+
 	lib "github.com/bazooka-ci/bazooka/commons"
 	"github.com/bazooka-ci/bazooka/commons/mongo"
 )
@@ -13,6 +15,7 @@ const (
 	BazookaEnvSCMKeyfile = "BZK_SCM_KEYFILE"
 	BazookaEnvHome       = "BZK_HOME"
 	BazookaEnvDockerSock = "BZK_DOCKERSOCK"
+	BazookaEnvSyslogUrl  = "BZK_SYSLOG_URL"
 	BazookaEnvMongoAddr  = "MONGO_PORT_27017_TCP_ADDR"
 	BazookaEnvMongoPort  = "MONGO_PORT_27017_TCP_PORT"
 
@@ -22,6 +25,7 @@ const (
 )
 
 type context struct {
+	syslogUrl string
 	mongoAddr string
 	mongoPort string
 	connector *mongo.MongoConnector
@@ -43,6 +47,7 @@ type path struct {
 
 func initContext() *context {
 	c := &context{
+		syslogUrl: os.Getenv(BazookaEnvSyslogUrl),
 		mongoAddr: os.Getenv(BazookaEnvMongoAddr),
 		mongoPort: os.Getenv(BazookaEnvMongoPort),
 		paths: paths{
@@ -57,6 +62,8 @@ func initContext() *context {
 		log.Fatalf("Cannot connect to the database: %v", err)
 	}
 	c.connector = mongo.NewConnector()
+
+	fmt.Printf("server init, context=%#v\n", c)
 	return c
 }
 

--- a/server/log.go
+++ b/server/log.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bufio"
+	"net"
+
+	"io"
+
+	log "github.com/Sirupsen/logrus"
+	lib "github.com/bazooka-ci/bazooka/commons"
+	"github.com/bazooka-ci/bazooka/commons/syslogparser"
+)
+
+func (c *context) startLogServer(iface string) {
+	server, err := net.Listen("tcp", iface)
+	if err != nil {
+		log.Fatalf("Cannot listen: %v", err)
+	}
+	defer server.Close()
+
+	for {
+		conn, err := server.Accept()
+		if err != nil {
+			log.Errorf("Cannot accept log conn: %v", err)
+		}
+
+		go c.handleLogConn(conn)
+	}
+}
+
+func (c *context) handleLogConn(conn net.Conn) {
+	defer conn.Close()
+	r := bufio.NewReader(conn)
+	for {
+		line, err := r.ReadBytes('\n')
+		if err != nil {
+			if err != io.EOF {
+				log.Errorf("Error reading log: %v\n", err)
+			}
+			return
+		}
+
+		p, err := syslogparser.Parse(line)
+		if err != nil {
+			return
+		}
+
+		template := lib.LogEntry{
+			ProjectID: p.Meta["project"],
+			JobID:     p.Meta["job"],
+			VariantID: p.Meta["variant"],
+			Image:     p.Meta["image"],
+			Time:      p.Timestamp,
+		}
+		entry := lib.ConstructLog(p.Content, template)
+		if err := c.connector.AddLog(&entry); err != nil {
+			log.Errorf("Error adding log entry %v: %v", entry, err)
+		}
+	}
+}

--- a/server/main.go
+++ b/server/main.go
@@ -80,7 +80,13 @@ func main() {
 	http.Handle("/", r)
 
 	go func() {
+		log.Infof("Starting API server on port 3000")
 		log.Fatal(http.ListenAndServe(":3000", nil))
+	}()
+
+	go func() {
+		log.Infof("Starting Syslog server on port 3001")
+		context.startLogServer(":3001")
 	}()
 
 	signals := make(chan os.Signal, 1)


### PR DESCRIPTION
Replaces the old way of capturing logs (stream docker logs to a pipe with a scanner on the reader to write to mongo) with a new one based on docker's syslog logging driver.

* The server listens for TCP connections on port 3001
* Build containers are started configured to stream their logs to that endpoint (`tcp://server:3001`) using the syslog driver and format
* The server parses and stores the logs in mongo

For this feature to work, the server needs to know its address, so that when it starts an orchestration container, it can configure it with the syslog endpoint.
This is set in the `BZK_SYSLOG_URL` in the server.
The CLI was modified to set that variable from the `--syslog-uri` flag (which has a default value of `$BZK_SYSLOG_URL` in the host).
For example:

```
bzk service start --syslog-uri="tcp://$(docker-machine ip main):3001"
```