### PR TITLE
Add an internal API to manipulate jobs and variants

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -14,11 +14,12 @@ type Config struct {
 }
 
 type Client struct {
-	Project *Project
-	Job     *Job
-	Variant *Variant
-	Image   *Image
-	User    *User
+	Project  *Project
+	Job      *Job
+	Variant  *Variant
+	Image    *Image
+	User     *User
+	Internal *Internal
 }
 
 func New(config *Config) (*Client, error) {
@@ -28,10 +29,11 @@ func New(config *Config) (*Client, error) {
 			Key:    &ProjectKey{config},
 			Config: &ProjectConfig{config},
 		},
-		Job:     &Job{config},
-		Variant: &Variant{config},
-		Image:   &Image{config},
-		User:    &User{config},
+		Job:      &Job{config},
+		Variant:  &Variant{config},
+		Image:    &Image{config},
+		User:     &User{config},
+		Internal: &Internal{config},
 	}, nil
 }
 

--- a/client/internal.go
+++ b/client/internal.go
@@ -1,0 +1,88 @@
+package client
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+
+	lib "github.com/bazooka-ci/bazooka/commons"
+	"github.com/racker/perigee"
+)
+
+type Internal struct {
+	config *Config
+}
+
+func (in *Internal) GetProjectCryptoKey(projectID string) (*lib.CryptoKey, error) {
+	requestURL, err := in.config.getRequestURL(fmt.Sprintf("_/project/%s/crypto-key", projectID))
+	if err != nil {
+		return nil, err
+	}
+	var cryptoKey lib.CryptoKey
+	err = perigee.Get(requestURL, perigee.Options{
+		Results:    &cryptoKey,
+		OkCodes:    []int{200},
+		SetHeaders: in.config.authenticateRequest,
+	})
+	return &cryptoKey, err
+}
+
+func (in *Internal) MarkJobAsFinished(jobID string, status lib.JobStatus) error {
+	requestURL, err := in.config.getRequestURL(fmt.Sprintf("_/job/%s/finish", url.QueryEscape(jobID)))
+	if err != nil {
+		return err
+	}
+
+	return perigee.Post(requestURL, perigee.Options{
+		ReqBody: lib.FinishData{
+			Status: status,
+		},
+		OkCodes:    []int{204},
+		SetHeaders: in.config.authenticateRequest,
+	})
+}
+
+func (in *Internal) MarkVariantAsFinished(variantID string, status lib.JobStatus, when time.Time, artifacts []string) error {
+	requestURL, err := in.config.getRequestURL(fmt.Sprintf("_/variant/%s/finish", url.QueryEscape(variantID)))
+	if err != nil {
+		return err
+	}
+
+	return perigee.Post(requestURL, perigee.Options{
+		ReqBody: lib.FinishData{
+			Status:    status,
+			Time:      when,
+			Artifacts: artifacts,
+		},
+		OkCodes:    []int{204},
+		SetHeaders: in.config.authenticateRequest,
+	})
+}
+
+func (in *Internal) AddJobSCMMetadata(jobID string, m *lib.SCMMetadata) error {
+	requestURL, err := in.config.getRequestURL(fmt.Sprintf("_/job/%s/scm", url.QueryEscape(jobID)))
+	if err != nil {
+		return err
+	}
+
+	return perigee.Put(requestURL, perigee.Options{
+		ReqBody:    &m,
+		OkCodes:    []int{204},
+		SetHeaders: in.config.authenticateRequest,
+	})
+}
+
+func (in *Internal) AddVariant(variant *lib.Variant) (*lib.Variant, error) {
+	requestURL, err := in.config.getRequestURL("_/variant")
+	if err != nil {
+		return nil, err
+	}
+	var createdVariant lib.Variant
+	err = perigee.Post(requestURL, perigee.Options{
+		ReqBody:    &variant,
+		Results:    &createdVariant,
+		OkCodes:    []int{201},
+		SetHeaders: in.config.authenticateRequest,
+	})
+	return &createdVariant, err
+}

--- a/commons/project.go
+++ b/commons/project.go
@@ -94,6 +94,12 @@ type SCMMetadata struct {
 	Message   string   `bson:"message" json:"message" yaml:"message"`
 }
 
+type FinishData struct {
+	Status    JobStatus `json:"status"`
+	Time      time.Time `json:"time,omitempty"`
+	Artifacts []string  `json:"artifacts,omitempty"`
+}
+
 func (ms *VariantMetas) Append(m *VariantMeta) { *ms = append(*ms, m) }
 func (ms *VariantMetas) Len() int              { return len(*ms) }
 func (ms *VariantMetas) Swap(i, j int)         { (*ms)[i], (*ms)[j] = (*ms)[j], (*ms)[i] }

--- a/server/internal.go
+++ b/server/internal.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+
+	lib "github.com/bazooka-ci/bazooka/commons"
+
+	"time"
+)
+
+func (c *context) finishJob(r *request) (*response, error) {
+	var f lib.FinishData
+	r.parseBody(&f)
+	if f.Time.IsZero() {
+		f.Time = time.Now()
+	}
+	if err := c.connector.FinishJob(r.vars["id"], f.Status, f.Time); err != nil {
+		return nil, err
+	}
+
+	return noContent()
+}
+
+func (c *context) finishVariant(r *request) (*response, error) {
+	var f lib.FinishData
+	r.parseBody(&f)
+	if f.Time.IsZero() {
+		f.Time = time.Now()
+	}
+	if err := c.connector.FinishVariant(r.vars["id"], f.Status, f.Time, f.Artifacts); err != nil {
+		return nil, err
+	}
+
+	return noContent()
+}
+
+func (c *context) addJobScmData(r *request) (*response, error) {
+	var m lib.SCMMetadata
+	r.parseBody(&m)
+	if err := c.connector.AddJobSCMMetadata(r.vars["id"], &m); err != nil {
+		return nil, err
+	}
+
+	return noContent()
+}
+
+func (c *context) addVariant(r *request) (*response, error) {
+	var variant lib.Variant
+	r.parseBody(&variant)
+
+	if err := c.connector.AddVariant(&variant); err != nil {
+		return nil, err
+	}
+
+	return created(&variant, fmt.Sprintf("/variant/%s", variant.ID))
+}
+
+func (c *context) getCryptoKey(r *request) (*response, error) {
+	key, err := c.connector.GetProjectCryptoKey(r.vars["id"])
+	if err != nil {
+		return nil, err
+	}
+
+	return ok(&key)
+}

--- a/server/main.go
+++ b/server/main.go
@@ -67,6 +67,16 @@ func main() {
 
 	r.HandleFunc("/project/{id}/github", context.mkGithubAuthHandler(context.startGithubJob)).Methods("POST")
 
+	{
+		i := r.PathPrefix("/_").Subrouter()
+
+		i.HandleFunc("/project/{id}/crypto-key", context.mkInternalApiHandler(context.getCryptoKey)).Methods("GET")
+		i.HandleFunc("/job/{id}/finish", context.mkInternalApiHandler(context.finishJob)).Methods("POST")
+		i.HandleFunc("/job/{id}/scm", context.mkInternalApiHandler(context.addJobScmData)).Methods("PUT")
+		i.HandleFunc("/variant/{id}/finish", context.mkInternalApiHandler(context.finishVariant)).Methods("POST")
+		i.HandleFunc("/variant", context.mkInternalApiHandler(context.addVariant)).Methods("POST")
+	}
+
 	http.Handle("/", r)
 
 	go func() {

--- a/server/server.go
+++ b/server/server.go
@@ -216,6 +216,13 @@ func (ctx *context) authenticationHandler(next http.Handler) func(http.ResponseW
 	}
 }
 
+func (ctx *context) mkInternalApiHandler(f func(*request) (*response, error)) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		mkHandler(f).ServeHTTP(w, r)
+	}
+}
+
+
 func (ctx *context) userAuthentication(email string, password string) bool {
 	return ctx.connector.ComparePassword(email, password)
 }


### PR DESCRIPTION
This internal API is intended to be used by orchestration to manipulate jobs and variants using only the API instead of mongo.

For the time being, no specific security scheme is applied to the internal API.
The goal is to implement one in the future to restrict this API to the bazooka components and plugins.