### PR TITLE
Fix error when registering an image

### DIFF
--- a/server/image.go
+++ b/server/image.go
@@ -1,5 +1,7 @@
 package main
 
+import "strings"
+
 func (c *context) getImage(r *request) (*response, error) {
 	image, err := c.connector.GetImage(r.vars["name"])
 	if err != nil {
@@ -22,13 +24,15 @@ func (c *context) getImages(r *request) (*response, error) {
 }
 
 func (c *context) setImage(r *request) (*response, error) {
-	b := map[string]string{}
+	b := struct {
+		Image string `json:"image" validate:"required"`
+	}{}
 	r.parseBody(&b)
-	image, ex := b["image"]
-	if !ex {
+	b.Image = strings.TrimSpace(b.Image)
+	if len(b.Image) == 0 {
 		return badRequest("image is required")
 	}
-	err := c.connector.SetImage(r.vars["name"], image)
+	err := c.connector.SetImage(r.vars["name"], b.Image)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The error was caused by parsing the json body into a map, whereas the
validator (automatically invoked) expects a struct