### PR TITLE
Use defer to remove containers

### DIFF
--- a/commons/container.go
+++ b/commons/container.go
@@ -1,0 +1,20 @@
+package bazooka
+
+import (
+	log "github.com/Sirupsen/logrus"
+	docker "github.com/bywan/go-dockercommand"
+)
+
+// RemoveContainer will cleanly remove a Docker container and warn user of a leak in case of error
+func RemoveContainer(container *docker.Container) {
+	err := container.Remove(&docker.RemoveOptions{
+		Force:         true,
+		RemoveVolumes: true,
+	})
+	if err != nil {
+		log.WithFields(log.Fields{
+			"name":  container.ID(),
+			"error": err.Error(),
+		}).Error("Error while removing service container, Be aware that this could cause container leaks if services have not been removed correctly")
+	}
+}

--- a/orchestration/parser.go
+++ b/orchestration/parser.go
@@ -75,20 +75,14 @@ func (p *Parser) Parse() ([]*variantData, error) {
 		return nil, err
 	}
 
+	defer lib.RemoveContainer(container)
+
 	exitCode, err := container.Wait()
 	if err != nil {
 		return nil, err
 	}
 	if exitCode != 0 {
 		return nil, fmt.Errorf("Error during execution of Parser container %s/parser\n Check Docker container logs, id is %s\n", image, container.ID())
-	}
-
-	err = container.Remove(&docker.RemoveOptions{
-		Force:         true,
-		RemoveVolumes: true,
-	})
-	if err != nil {
-		return nil, err
 	}
 
 	log.WithFields(log.Fields{

--- a/orchestration/runner.go
+++ b/orchestration/runner.go
@@ -81,6 +81,7 @@ func (r *Runner) runContainer(vd *variantData) error {
 		if err != nil {
 			return err
 		}
+		defer commons.RemoveContainer(serviceContainer)
 		serviceContainers = append(serviceContainers, serviceContainer)
 	}
 
@@ -110,6 +111,7 @@ func (r *Runner) runContainer(vd *variantData) error {
 	if err != nil {
 		return err
 	}
+	defer commons.RemoveContainer(container)
 
 	exitCode, err := container.Wait()
 	if err != nil {
@@ -120,21 +122,6 @@ func (r *Runner) runContainer(vd *variantData) error {
 			return fmt.Errorf("Run failed\n Check Docker container logs, id is %s\n", container.ID())
 		}
 		success = false
-	}
-	if err = container.Remove(&docker.RemoveOptions{
-		Force:         true,
-		RemoveVolumes: true,
-	}); err != nil {
-		return err
-	}
-
-	for _, serviceContainer := range serviceContainers {
-		if err = serviceContainer.Remove(&docker.RemoveOptions{
-			Force:         true,
-			RemoveVolumes: true,
-		}); err != nil {
-			return err
-		}
 	}
 
 	if success {

--- a/orchestration/scmfectch.go
+++ b/orchestration/scmfectch.go
@@ -65,6 +65,8 @@ func (f *SCMFetcher) Fetch() error {
 		return err
 	}
 
+	defer lib.RemoveContainer(container)
+
 	exitCode, err := container.Wait()
 	if err != nil {
 		return err
@@ -76,11 +78,6 @@ func (f *SCMFetcher) Fetch() error {
 	log.WithFields(log.Fields{
 		"checkout_folder": paths.source.host,
 	}).Info("SCM Source Repo Fetched")
-
-	err = container.Remove(&docker.RemoveOptions{
-		Force:         true,
-		RemoveVolumes: true,
-	})
 
 	scmMetadata := &lib.SCMMetadata{}
 

--- a/parser/language_parser.go
+++ b/parser/language_parser.go
@@ -48,6 +48,8 @@ func (p *LanguageParser) Parse() ([]*variantData, error) {
 		return nil, err
 	}
 
+	defer lib.RemoveContainer(container)
+
 	container.Logs(p.image)
 
 	exitCode, err := container.Wait()
@@ -58,13 +60,6 @@ func (p *LanguageParser) Parse() ([]*variantData, error) {
 		return nil, fmt.Errorf("Error during execution of Language Parser container %s/parser\n Check Docker container logs, id is %s\n", p.image, container.ID())
 	}
 
-	err = container.Remove(&docker.RemoveOptions{
-		Force:         true,
-		RemoveVolumes: true,
-	})
-	if err != nil {
-		return nil, err
-	}
 	log.Info("Language parsing finished")
 
 	// if all went well, the parser should have generated one or more "sub" .bazooka.*.yml files


### PR DESCRIPTION
Bazooka will now systematically use a `defer` function to remove containers created during the build of a project

This function is common to all the modules, and is available in `commons/container.go`

Closes #271