### PR TITLE
Replace links with Docker 1.9 bridge networks

### DIFF
--- a/cli/bzk/bzk.go
+++ b/cli/bzk/bzk.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	app    = cli.App("bzk", "Bazooka CI client")
+	app       = cli.App("bzk", "Bazooka CI client")
 	bzkApiUrl = app.String(cli.StringOpt{
 		Name:   "u bazooka-url",
 		Desc:   "URL for the bazooka server",

--- a/cli/bzk/config.go
+++ b/cli/bzk/config.go
@@ -17,9 +17,9 @@ const (
 
 // TODO handle multiple server
 type Config struct {
-	Username   string `yaml:"username,omitempty"`
-	Password   string `yaml:"password,omitempty"`
-	Auth       string `yaml:"auth"`
+	Username string `yaml:"username,omitempty"`
+	Password string `yaml:"password,omitempty"`
+	Auth     string `yaml:"auth"`
 
 	ApiURL     string `yaml:"api_url"`
 	SyslogURL  string `yaml:"syslog_url"`
@@ -29,7 +29,7 @@ type Config struct {
 	Registry   string `yaml:"registry"`
 	Tag        string `yaml:"tag"`
 
-	MongoURL   string `yaml:"mongo_url"`
+	DbURL string `yaml:"db_url"`
 }
 
 func saveConfig(authConfig *Config) error {

--- a/commons/mongo/connector.go
+++ b/commons/mongo/connector.go
@@ -3,7 +3,6 @@ package mongo
 import (
 	"crypto/rand"
 	"fmt"
-	"os"
 
 	mgo "gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
@@ -42,8 +41,8 @@ func (m *ManyFoundError) Error() string {
 	return fmt.Sprintf("%s[%s:%s] returned %d results", m.Collection, m.Field, m.Value, m.Count)
 }
 
-func NewConnector() *MongoConnector {
-	session, err := mgo.Dial(getMongoUrl())
+func NewConnector(url string) *MongoConnector {
+	session, err := mgo.Dial(url)
 	if err != nil {
 		panic(err)
 	}
@@ -122,12 +121,4 @@ func (m *MongoConnector) selectOneByIdOrName(collection, id string, result inter
 	default:
 		return err
 	}
-}
-
-func getMongoUrl() string {
-	mongoURL := os.Getenv(bazookaEnvMongoURL)
-	if mongoURL != "" {
-		return mongoURL
-	}
-	return os.Getenv(bazookaEnvMongoAddr) + ":" + os.Getenv(bazookaEnvMongoPort)
 }

--- a/commons/net.go
+++ b/commons/net.go
@@ -6,8 +6,7 @@ import (
 	"time"
 )
 
-func WaitForTcpConnection(host, port string, retryEvery, timeout time.Duration) error {
-	url := fmt.Sprintf("%s:%s", host, port)
+func WaitForTcpConnection(url string, retryEvery, timeout time.Duration) error {
 	giveUp := time.After(timeout)
 	for {
 		select {
@@ -18,7 +17,7 @@ func WaitForTcpConnection(host, port string, retryEvery, timeout time.Duration) 
 				return nil
 			}
 		case <-giveUp:
-			return fmt.Errorf("Coudln't establish a connection to %s:%s after %v", host, port, timeout)
+			return fmt.Errorf("Coudln't establish a connection to %s after %v", url, timeout)
 		}
 	}
 }

--- a/hack/bazooka-compose/README.md
+++ b/hack/bazooka-compose/README.md
@@ -1,0 +1,11 @@
+# Docker compose config for bazooka
+
+The `docker-compose.yml` file provides a docker compose configuration to get started with bazooka.
+ 
+Simply move to the directory containing the `docker-compose.yml` file and execute the following command:
+
+```
+docker-compose --x-networking up
+```
+
+Note the `--x-networking` flag, which is required for bazooka to work.

--- a/hack/bazooka-compose/docker-compose.yml
+++ b/hack/bazooka-compose/docker-compose.yml
@@ -1,0 +1,29 @@
+server:
+  container_name: bzk_server
+  image: bazooka/server
+  ports:
+  - "3000:3000"
+  - "3001:3001"
+  volumes:
+  - "${BZK_HOME}:/bazooka"
+  - "/var/run/docker.sock:/var/run/docker.sock"
+  environment:
+  - "BZK_DOCKERSOCK=/var/run/docker.sock"
+  - "BZK_API_URL=http://bzk_server:3000"
+  - "BZK_SYSLOG_URL=${BZK_SYSLOG_URL}"
+  - "BZK_DB_URL=bzk_db:27017"
+  - "BZK_NETWORK=bazookacompose"
+  - "BZK_SCM_KEYFILE=${BZK_SCM_KEYFILE}"
+  - "BZK_HOME=${BZK_HOME}"
+
+web:
+  container_name: bzk_web
+  image: bazooka/web
+  ports:
+  - "8000:80"
+  environment:
+  - "BZK_SERVER_HOST=bzk_server"
+
+db:
+  container_name: bzk_db
+  image: "mongo:3.1"

--- a/hack/capitan/README.md
+++ b/hack/capitan/README.md
@@ -1,0 +1,15 @@
+# Capitan config file for Bazooka
+
+The `capitan.cfg.sh` file provides a configuration to get started with bazooka using capitan: https://github.com/byrnedo/capitan.
+
+Once capitan is installed:
+
+```
+go get github.com/byrnedo/capitan
+```
+ 
+Simply move to the directory containing the `capitan.cfg.sh` file and execute the following command:
+
+```
+capitan up
+```

--- a/hack/capitan/capitan.cfg.sh
+++ b/hack/capitan/capitan.cfg.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+if [[ $DOCKER_HOST =~ tcp://(.*):.* ]]
+then
+    DOCKER0=${BASH_REMATCH[1]}
+else
+    DOCKER0=$(ip -4 a show docker0 | grep -oP "(?<=inet ).*(?=/)")
+fi
+
+NET=bzk_net
+
+if docker network inspect ${NET} > /dev/null 2>&1
+then
+    true
+else
+    docker network create -d=bridge ${NET} > /dev/null 2>&1
+fi
+
+cat <<EOF
+global project bzk
+
+#
+# DB container
+#
+db image mongo:3.1
+db net ${NET}
+
+#
+# server container
+#
+server image bazooka/server
+server net ${NET}
+server publish 3000:3000
+server publish 3001:3001
+server volume ${BZK_HOME}:/bazooka
+server volume /var/run/docker.sock:/var/run/docker.sock
+server env BZK_DOCKERSOCK=/var/run/docker.sock
+server env BZK_API_URL=http://bzk_server:3000
+server env BZK_SYSLOG_URL=tcp://${DOCKER0}:3001
+server env BZK_DB_URL=bzk_db:27017
+server env BZK_NETWORK=bzk_net
+server env BZK_SCM_KEYFILE=${BZK_SCM_KEYFILE}
+server env BZK_HOME=${BZK_HOME}
+
+#
+# Web container
+#
+web image bazooka/web
+web net ${NET}
+web publish 8000:80
+web env BZK_SERVER_HOST=bzk_server
+EOF

--- a/hack/crowdr/README.md
+++ b/hack/crowdr/README.md
@@ -1,0 +1,17 @@
+# Crowdr config file for Bazooka
+
+**Linux only, doesn't work on Mac OS X**
+
+The `crowdr.cfg.sh` file provides a configuration to get started with bazooka using crowdr: https://github.com/polonskiy/crowdr.
+
+Once crowdr is installed:
+
+```
+curl -s https://raw.githubusercontent.com/polonskiy/crowdr/0.9.1/crowdr > /usr/local/bin/crowdr
+```
+ 
+Simply move to the directory containing the `crowdr.cfg.sh` file and execute the following command:
+
+```
+crowdr run
+```

--- a/hack/crowdr/crowdr.cfg.sh
+++ b/hack/crowdr/crowdr.cfg.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+if [[ $DOCKER_HOST =~ tcp://(.*):.* ]]
+then
+    DOCKER0=${BASH_REMATCH[1]}
+else
+    DOCKER0=$(ip -4 a show docker0 | grep -oP "(?<=inet ).*(?=/)")
+fi
+
+
+NET=bzk_net
+
+if docker network inspect ${NET} > /dev/null 2>&1
+then
+    true
+else
+    docker network create -d=bridge ${NET} > /dev/null 2>&1
+fi
+
+cat <<EOF
+global project bzk
+
+#
+# DB container
+#
+db image mongo:3.1
+db net ${NET}
+
+#
+# server container
+#
+server image bazooka/server
+server net ${NET}
+server publish 3000:3000
+server publish 3001:3001
+server volume ${BZK_HOME}:/bazooka
+server volume /var/run/docker.sock:/var/run/docker.sock
+server env BZK_DOCKERSOCK=/var/run/docker.sock
+server env BZK_API_URL=http://bzk_server:3000
+server env BZK_SYSLOG_URL=tcp://${DOCKER0}:3001
+server env BZK_DB_URL=bzk_db:27017
+server env BZK_NETWORK=bzk_net
+server env BZK_SCM_KEYFILE=${BZK_SCM_KEYFILE}
+server env BZK_HOME=${BZK_HOME}
+
+#
+# Web container
+#
+web image bazooka/web
+web net ${NET}
+web publish 8000:80
+web env BZK_SERVER_HOST=bzk_server
+EOF

--- a/orchestration/Dockerfile
+++ b/orchestration/Dockerfile
@@ -2,4 +2,4 @@ FROM busybox:ubuntu-14.04
 
 COPY main /bin/main
 
-ENTRYPOINT /bin/main
+CMD /bin/main

--- a/orchestration/context.go
+++ b/orchestration/context.go
@@ -8,12 +8,12 @@ import (
 	"log"
 
 	"github.com/bazooka-ci/bazooka/client"
-	"github.com/bazooka-ci/bazooka/commons/mongo"
 )
 
 const (
 	BazookaEnvApiUrl        = "BZK_API_URL"
 	BazookaEnvSyslogUrl     = "BZK_SYSLOG_URL"
+	BazookaEnvNetwork       = "BZK_NETWORK"
 	BazookaEnvHome          = "BZK_HOME"
 	BazookaEnvSrc           = "BZK_SRC"
 	BazookaEnvSCMKeyfile    = "BZK_SCM_KEYFILE"
@@ -28,10 +28,10 @@ const (
 )
 
 type context struct {
-	connector     *mongo.MongoConnector
 	client        *client.Client
 	apiUrl        string
 	syslogUrl     string
+	network       string
 	scm           string
 	scmUrl        string
 	scmReference  string
@@ -61,8 +61,9 @@ type path struct {
 
 func initContext() *context {
 	// Configure Client
+	apiUrl := os.Getenv(BazookaEnvApiUrl)
 	client, err := client.New(&client.Config{
-		URL: os.Getenv(BazookaEnvApiUrl),
+		URL: apiUrl,
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -72,6 +73,7 @@ func initContext() *context {
 		client:        client,
 		apiUrl:        os.Getenv(BazookaEnvApiUrl),
 		syslogUrl:     os.Getenv(BazookaEnvSyslogUrl),
+		network:       os.Getenv(BazookaEnvNetwork),
 		scm:           os.Getenv(BazookaEnvSCM),
 		scmUrl:        os.Getenv(BazookaEnvSCMUrl),
 		scmReference:  os.Getenv(BazookaEnvSCMReference),

--- a/orchestration/parser.go
+++ b/orchestration/parser.go
@@ -45,6 +45,7 @@ func (p *Parser) Parse() ([]*variantData, error) {
 	env := map[string]string{
 		BazookaEnvApiUrl:        p.context.apiUrl,
 		BazookaEnvSyslogUrl:     p.context.syslogUrl,
+		BazookaEnvNetwork:       p.context.network,
 		BazookaEnvHome:          paths.base.host,
 		BazookaEnvSrc:           paths.source.host,
 		BazookaEnvProjectID:     p.context.projectID,
@@ -69,6 +70,7 @@ func (p *Parser) Parse() ([]*variantData, error) {
 		Env:                 env,
 		VolumeBinds:         volumes,
 		Detach:              true,
+		NetworkMode:         p.context.network,
 		LoggingDriver:       "syslog",
 		LoggingDriverConfig: p.context.loggerConfig(image, ""),
 	})

--- a/orchestration/scmfectch.go
+++ b/orchestration/scmfectch.go
@@ -58,6 +58,7 @@ func (f *SCMFetcher) Fetch() error {
 		VolumeBinds:         volumes,
 		Env:                 env,
 		Detach:              true,
+		NetworkMode:         f.context.network,
 		LoggingDriver:       "syslog",
 		LoggingDriverConfig: f.context.loggerConfig(image, ""),
 	})

--- a/parser/context.go
+++ b/parser/context.go
@@ -25,7 +25,9 @@ const (
 
 type context struct {
 	client        *client.Client
+	apiUrl        string
 	syslogUrl     string
+	network       string
 	projectID     string
 	jobID         string
 	jobParameters string
@@ -47,15 +49,17 @@ type path struct {
 }
 
 func initContext() *context {
+	apiUrl := os.Getenv(BazookaEnvApiUrl)
 	// Configure Client
 	client, err := client.New(&client.Config{
-		URL: os.Getenv(BazookaEnvApiUrl),
+		URL: apiUrl,
 	})
 	if err != nil {
 		log.Fatal(err)
 	}
 	return &context{
 		client:        client,
+		apiUrl:        apiUrl,
 		syslogUrl:     os.Getenv(BazookaEnvSyslogUrl),
 		projectID:     os.Getenv(BazookaEnvProjectID),
 		jobID:         os.Getenv(BazookaEnvJobID),

--- a/server/job.go
+++ b/server/job.go
@@ -252,6 +252,9 @@ func (c *context) runJob(startJob *lib.StartJob, runningJob *lib.Job, commitID s
 		container: fmt.Sprintf(buildFolderPattern, c.paths.home.container, runningJob.ProjectID, runningJob.ID),
 	}
 	orchestrationEnv := map[string]string{
+		BazookaEnvApiUrl:     c.apiUrl,
+		BazookaEnvSyslogUrl:  c.syslogUrl,
+		BazookaEnvNetwork:    c.network,
 		"BZK_SCM":            project.ScmType,
 		"BZK_SCM_URL":        project.ScmURI,
 		"BZK_SCM_REFERENCE":  refToBuild,
@@ -261,8 +264,6 @@ func (c *context) runJob(startJob *lib.StartJob, runningJob *lib.Job, commitID s
 		"BZK_JOB_ID":         runningJob.ID,
 		"BZK_DOCKERSOCK":     c.paths.dockerSock.host,
 		"BZK_JOB_PARAMETERS": string(jobParameters),
-		BazookaEnvApiUrl:     c.apiUrl,
-		BazookaEnvSyslogUrl:  c.syslogUrl,
 	}
 
 	projectSSHKey, err := c.connector.GetProjectKey(project.ID)
@@ -344,6 +345,7 @@ func (c *context) runJob(startJob *lib.StartJob, runningJob *lib.Job, commitID s
 		VolumeBinds:   orchestrationVolumes,
 		Env:           orchestrationEnv,
 		Detach:        true,
+		NetworkMode:   c.network,
 		LoggingDriver: "syslog",
 		LoggingDriverConfig: map[string]string{
 			"syslog-address": c.syslogUrl,

--- a/server/project.go
+++ b/server/project.go
@@ -75,7 +75,6 @@ func (p *context) getProject(r *request) (*response, error) {
 
 func (c *context) getProjects(r *request) (*response, error) {
 	includeStatus := len(r.r.URL.Query().Get("include-status")) > 0
-
 	if includeStatus {
 		projects, err := c.connector.GetProjectsWithStatus()
 		if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -222,7 +222,6 @@ func (ctx *context) mkInternalApiHandler(f func(*request) (*response, error)) fu
 	}
 }
 
-
 func (ctx *context) userAuthentication(email string, password string) bool {
 	return ctx.connector.ComparePassword(email, password)
 }

--- a/web/conf/Dockerfile
+++ b/web/conf/Dockerfile
@@ -3,7 +3,7 @@ FROM nginx
 COPY web/ /usr/share/nginx/html/
 
 COPY bzk-web.conf /etc/nginx/conf.d/default.conf
-COPY substitute.sh /
-RUN chmod +x /substitute.sh
+COPY wait-for-server.sh /
+RUN chmod +x /wait-for-server.sh
 
-ENTRYPOINT ["/substitute.sh"]
+ENTRYPOINT ["/wait-for-server.sh"]

--- a/web/conf/bzk-web.conf
+++ b/web/conf/bzk-web.conf
@@ -1,5 +1,5 @@
 upstream bzk_server  {
-    server <bzk_server_placeholder>;
+    server <bzk_server_placeholder>:3000;
 }
 
 server {

--- a/web/conf/substitute.sh
+++ b/web/conf/substitute.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-set -eu
-echo "injecting env vars"
-/bin/sed -i "s/<bzk_server_placeholder>/${SERVER_PORT_3000_TCP_ADDR}:${SERVER_PORT_3000_TCP_PORT}/" /etc/nginx/conf.d/default.conf
-
-exec nginx -g "daemon off;"

--- a/web/conf/wait-for-server.sh
+++ b/web/conf/wait-for-server.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -eu
+
+until grep $BZK_SERVER_HOST /etc/hosts
+do
+    echo "waiting for server to come up"
+    sleep 1
+done
+
+/bin/sed -i "s/<bzk_server_placeholder>/${BZK_SERVER_HOST}/" /etc/nginx/conf.d/default.conf
+
+exec nginx -g "daemon off;"


### PR DESCRIPTION
Bazooka used to rely on links to work:

* The DB container was linked into the server container
* The server container was linked into the web container

This PR proposes to replace these links (which are to be considered a
deprecated and legacy feature in Docker) with the usage of bridge
networks:

`bzk service start` will create a `bzk_net` network if it doesn't
exist, and attach the db, server and containers to it for them to be
able to communicate.

The build flow was also modified so that the various build containers
(orchestration, parser, ...) are attached to the same network when
started.

This PR also adds:
* a working docker compose config capable of starting bazooka using docker compose
* a [crowdr](https://github.com/polonskiy/crowdr) config
* a [capitan](https://github.com/byrnedo/capitan) config