### PR TITLE
Get rid of gox

### DIFF
--- a/.bazooka.yml
+++ b/.bazooka.yml
@@ -6,7 +6,7 @@ install:
 script:
   - go test -v ./...
   - make errcheck
-  - make cli-gox
+  - make cli-multiplatform
   - make images
   - make push-bintray
   - make push

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ parser/parser
 server/server
 orchestration/orchestration
 site
+bzk
+bzk_linux_amd64
+bzk_darwin_amd64

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,6 @@ test: errcheck devimages # Include errcheck in build phase
 push-bintray:
 	./scripts/push-bintray.sh
 
-cli-gox:
-	gox -os="linux" github.com/bazooka-ci/bazooka/cli/bzk
-	gox -os="darwin" github.com/bazooka-ci/bazooka/cli/bzk
+cli-multiplatform:
+	GOOS=linux  GOARCH=amd64 go build -o=bzk_linux_amd64  github.com/bazooka-ci/bazooka/cli/bzk
+	GOOS=darwin GOARCH=amd64 go build -o=bzk_darwin_amd64 github.com/bazooka-ci/bazooka/cli/bzk

--- a/orchestration/Makefile
+++ b/orchestration/Makefile
@@ -1,7 +1,7 @@
 default: docker
 
-docker: gox
+docker: go
 	docker build -t bazooka/orchestration -f Dockerfile .
 
-gox:
-	gox -osarch="linux/amd64" -output="main"
+go:
+	GOOS=linux GOARCH=amd64 go build -o=main

--- a/parser/Makefile
+++ b/parser/Makefile
@@ -1,7 +1,7 @@
 default: docker
 
-docker: gox
+docker: go
 	docker build -t bazooka/parser -f Dockerfile .
 
-gox:
-	gox -osarch="linux/amd64" -output="main"
+go:
+	GOOS=linux GOARCH=amd64 go build -o=main

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -3,7 +3,6 @@ set -ev
 
 : ${GOPATH:?"GOPATH has to be set. See https://golang.org/doc/code.html#GOPATH for more information."}
 
-go get -u github.com/mitchellh/gox
 go get -u github.com/kisielk/errcheck
 
 go_projects=( "parser" "orchestration" "server" "cli" )

--- a/scripts/push-bintray.sh
+++ b/scripts/push-bintray.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-versions=( "linux_amd64" "linux_386" "linux_arm" "darwin_amd64" "darwin_386")
+versions=( "linux_amd64" "darwin_amd64")
 
 if [ -n "$DO_PUSH" ]; then
   if [ -z "$BZK_VERSION" ]; then

--- a/server/Makefile
+++ b/server/Makefile
@@ -1,7 +1,7 @@
 default: docker
 
-docker: gox
+docker: go
 	docker build -t bazooka/server -f Dockerfile .
 
-gox:
-	gox -osarch="linux/amd64" -output="main"
+go:
+	GOOS=linux GOARCH=amd64 go build -o=main


### PR DESCRIPTION
Use the go compiler instead, which supports cross-compiling since 1.5