### PR TITLE
Fix the waiting for server loop in web

### DIFF
--- a/web/conf/wait-for-server.sh
+++ b/web/conf/wait-for-server.sh
@@ -2,6 +2,12 @@
 
 set -eu
 
+until ping -c1 $BZK_SERVER_HOST &>/dev/null
+do
+    echo "waiting for server to come up"
+    sleep 1
+done
+
 /bin/sed -i "s/<bzk_server_placeholder>/${BZK_SERVER_HOST}/" /etc/nginx/conf.d/default.conf
 
 exec nginx -g "daemon off;"


### PR DESCRIPTION
Before docker networking, hosts were added to /etc/hosts.

This is no longer the case, so the script was updated to use ping instead.
